### PR TITLE
revert: Remove unused parameters

### DIFF
--- a/src/libs/Parameters.sol
+++ b/src/libs/Parameters.sol
@@ -14,10 +14,4 @@ library Parameters {
 
     /// @notice The delay duration that must pass for to upgrade to a new implementation.
     uint32 internal constant DELAY_DURATION = 2 weeks;
-
-    /// @notice The claim start time (Sun Jun 01 2025 12:00:00 UTC).
-    uint48 internal constant CLAIM_START_TIME = 1748779200;
-
-    /// @notice The claim duration.
-    uint32 internal constant CLAIM_DURATION = 365 days;
 }


### PR DESCRIPTION
## Context
Two parameters belonging to the token-distributor contract that got moved into a separate repo still remained in the token repo.

## Scope
Remove the leftover parameters.