### PR TITLE
feat: update the `MIN_LOCKED_SUPPLY` parameter

### DIFF
--- a/src/libs/Parameters.sol
+++ b/src/libs/Parameters.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.30;
 
-// TODO! Replace placeholder values.
 library Parameters {
     /// @notice The total supply of the token.
     uint256 internal constant SUPPLY = 1_000_000_000;


### PR DESCRIPTION
This PR updates the `MIN_LOCKED_SUPPLY` threshold (see #26).
All other parameters stay as they are and aren't placeholders anymore.