### PR TITLE
style: silence linter warning

### DIFF
--- a/src/XanV1.sol
+++ b/src/XanV1.sol
@@ -325,7 +325,7 @@ contract XanV1 is IXanV1, Initializable, ERC20Upgradeable, ERC20BurnableUpgradea
 
     /// @notice Returns `true` if the quorum is reached for a particular implementation.
     function _isMinLockedSupplyReached() internal view virtual returns (bool isReached) {
-        isReached = lockedSupply() >= Parameters.MIN_LOCKED_SUPPLY;
+        isReached = lockedSupply() + 1 > Parameters.MIN_LOCKED_SUPPLY;
     }
 
     /// @notice Checks if the delay period has ended and reverts with errors if not.


### PR DESCRIPTION
See https://github.com/anoma/token/actions/runs/16049356137/job/45288084213?pr=27#step:13:10

Explanation: 

`a >= b` costs slightly more gas than `a+1 > b`

`a+1` overflowing is not a concern here