### PR TITLE
feat: test the foreign reserve execution behavior

### DIFF
--- a/test/mocks/Owner.m.sol
+++ b/test/mocks/Owner.m.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.30;
+
+import {ForeignReserveV1} from "../../src/ForeignReserveV1.sol";
+
+contract MockOwner {
+    ForeignReserveV1 internal _reserve;
+
+    constructor(ForeignReserveV1 reserve) {
+        _reserve = reserve;
+    }
+
+    function executeOnForeignReserve(address target, uint256 value, bytes calldata data) external {
+        _reserve.execute({target: target, value: value, data: data});
+    }
+}

--- a/test/mocks/Target.m.sol
+++ b/test/mocks/Target.m.sol
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.30;
 
-contract MockCallTarget {
+contract MockTarget {
     event Called(address indexed from, uint256 indexed value, bytes data);
+
+    error CallReverted();
 
     // solhint-disable-next-line no-empty-blocks
     receive() external payable {}
@@ -14,5 +16,9 @@ contract MockCallTarget {
     function ping() external payable returns (string memory message) {
         emit Called(msg.sender, msg.value, msg.data);
         message = "pong";
+    }
+
+    function revertingCall() external pure {
+        revert CallReverted();
     }
 }


### PR DESCRIPTION
This PR adds and refactors tests for the foreign reserve to make sure
- The function reverts if the target contract reverts.
- The function reverts when reentrant.

as flagged in the Zellic audit report (see https://github.com/anoma/token-distributor/issues/41).