### PR TITLE
doc: fix typos

### DIFF
--- a/src/libs/Parameters.sol
+++ b/src/libs/Parameters.sol
@@ -18,12 +18,12 @@ library Parameters {
     /// @notice The minimal locked supply required for upgrades amounting to 25% of the total supply.
     uint256 internal constant MIN_LOCKED_SUPPLY = SUPPLY / 4;
 
-    /// @notice The quorum ration numerator.
+    /// @notice The quorum ratio numerator.
     uint256 internal constant QUORUM_RATIO_NUMERATOR = 1;
 
-    /// @notice The quorum ration denominator.
+    /// @notice The quorum ratio denominator.
     uint256 internal constant QUORUM_RATIO_DENOMINATOR = 2;
 
-    /// @notice The delay duration that must pass for to upgrade to a new implementation.
+    /// @notice The delay duration that must pass to upgrade to a new implementation.
     uint32 internal constant DELAY_DURATION = 2 weeks;
 }


### PR DESCRIPTION
Fix typos in the parameters file.