### PR TITLE
refactor: put nonReentrant modifier in the first position

### DIFF
--- a/src/ForeignReserveV1.sol
+++ b/src/ForeignReserveV1.sol
@@ -55,8 +55,8 @@ contract ForeignReserveV1 is
         external
         payable
         override
-        onlyOwner
         nonReentrant
+        onlyOwner
         returns (bytes memory result)
     {
         result = target.functionCallWithValue(data, value);


### PR DESCRIPTION
## Context

In the audit report by informal, they suggest the following

> token
> - src/ForeignReserveV1.sol:
>   - Function execute() is decorated with the nonReentrant modifier, but it is not the first modifier applied. There is a risk that other modifiers, such as onlyOwner, could execute code that might inadvertently allow reentrancy vulnerabilities to be exploited before the nonReentrant check is enforced. To mitigate this risk, the nonReentrant modifier should be placed before all other modifiers to ensure that the reentrancy protection is applied as early as possible in the function execution.