### PR TITLE
fix: prevent a captured security council from vetoing its own removal

### DIFF
--- a/src/SecurityCouncil.sol
+++ b/src/SecurityCouncil.sol
@@ -109,7 +109,7 @@ contract SecurityCouncil is ISecurityCouncil {
         // The voter body's power to replace the council (`setCouncil`) must survive the council's brake; otherwise a
         // captured council could veto its own removal indefinitely. A `setCouncil` call is therefore the one
         // operation the council may not cancel.
-        if (target == address(this) && bytes4(data) == this.setCouncil.selector) {
+        if (target == address(this) && bytes4(data[:4]) == this.setCouncil.selector) {
             revert CannotCancelCouncilRotation();
         }
 
@@ -130,7 +130,7 @@ contract SecurityCouncil is ISecurityCouncil {
         // captured council could veto its own removal indefinitely. A standalone `setCouncil` call is therefore the one
         // operation the council may not cancel. Bundling it with anything else (length != 1) stays cancellable, so a
         // malicious upgrade cannot ride along under this exemption.
-        if (targets.length == 1 && targets[0] == address(this) && bytes4(payloads[0]) == this.setCouncil.selector) {
+        if (targets.length == 1 && targets[0] == address(this) && bytes4(payloads[0][:4]) == this.setCouncil.selector) {
             revert CannotCancelCouncilRotation();
         }
 

--- a/src/SecurityCouncil.sol
+++ b/src/SecurityCouncil.sol
@@ -111,7 +111,18 @@ contract SecurityCouncil is ISecurityCouncil {
     }
 
     /// @inheritdoc ISecurityCouncil
-    function cancel(bytes32 operationId) external override onlyCouncil {
+    function cancel(address[] calldata targets, uint256[] calldata values, bytes[] calldata payloads, bytes32 salt)
+        external
+        override
+        onlyCouncil
+        returns (bytes32 operationId)
+    {
+        // Voter-body operations are always batches scheduled with a zero predecessor (see
+        // `GovernorTimelockControl._queueOperations`), so the id is reconstructed accordingly.
+        operationId = _TIMELOCK.hashOperationBatch({
+            targets: targets, values: values, payloads: payloads, predecessor: bytes32(0), salt: salt
+        });
+
         emit ProposalCancelled(operationId);
 
         _TIMELOCK.cancel(operationId);

--- a/src/SecurityCouncil.sol
+++ b/src/SecurityCouncil.sol
@@ -100,18 +100,25 @@ contract SecurityCouncil is ISecurityCouncil {
     }
 
     /// @inheritdoc ISecurityCouncil
-    function cancelCouncilUpgrade() external override onlyCouncil returns (bytes32 operationId) {
-        operationId = _pendingOperation;
-        require(operationId != bytes32(0), NoUpgradeScheduled());
-        require(_TIMELOCK.isOperationPending(operationId), UpgradeNotPending());
+    function cancel(address target, uint256 value, bytes calldata data, bytes32 salt)
+        external
+        override
+        onlyCouncil
+        returns (bytes32 operationId)
+    {
+        // The voter body's power to replace the council (`setCouncil`) must survive the council's brake; otherwise a
+        // captured council could veto its own removal indefinitely. A `setCouncil` call is therefore the one
+        // operation the council may not cancel.
+        require(!(target == address(this) && bytes4(data) == this.setCouncil.selector), CannotCancelCouncilRotation());
 
-        emit CouncilUpgradeCancelled(operationId, msg.sender);
+        operationId =
+            _TIMELOCK.hashOperation({target: target, value: value, data: data, predecessor: bytes32(0), salt: salt});
 
-        _TIMELOCK.cancel(operationId);
+        _cancel(operationId);
     }
 
     /// @inheritdoc ISecurityCouncil
-    function cancel(address[] calldata targets, uint256[] calldata values, bytes[] calldata payloads, bytes32 salt)
+    function cancelBatch(address[] calldata targets, uint256[] calldata values, bytes[] calldata payloads, bytes32 salt)
         external
         override
         onlyCouncil
@@ -130,9 +137,7 @@ contract SecurityCouncil is ISecurityCouncil {
             targets: targets, values: values, payloads: payloads, predecessor: bytes32(0), salt: salt
         });
 
-        emit ProposalCancelled(operationId);
-
-        _TIMELOCK.cancel(operationId);
+        _cancel(operationId);
     }
 
     /// @inheritdoc ISecurityCouncil
@@ -155,6 +160,14 @@ contract SecurityCouncil is ISecurityCouncil {
     /// @inheritdoc ISecurityCouncil
     function cancelWindow() public view override returns (uint256 delay) {
         delay = _GOVERNOR.votingDelay() + _GOVERNOR.votingPeriod() + _TIMELOCK.getMinDelay() + _CANCEL_BUFFER;
+    }
+
+    /// @notice Internal helper to cancel a proposal with a given operation ID.
+    /// @param operationId The ID of the operation to cancel.
+    function _cancel(bytes32 operationId) internal {
+        emit ProposalCancelled(operationId);
+
+        _TIMELOCK.cancel(operationId);
     }
 
     /// @notice Deterministic, council-tagged salt so a council upgrade never collides with a voter-body operation and

--- a/src/SecurityCouncil.sol
+++ b/src/SecurityCouncil.sol
@@ -117,6 +117,15 @@ contract SecurityCouncil is ISecurityCouncil {
         onlyCouncil
         returns (bytes32 operationId)
     {
+        // The voter body's power to replace the council (`setCouncil`) must survive the council's brake; otherwise a
+        // captured council could veto its own removal indefinitely. A standalone `setCouncil` call is therefore the one
+        // operation the council may not cancel. Bundling it with anything else (length != 1) stays cancellable, so a
+        // malicious upgrade cannot ride along under this exemption.
+        require(
+            !(targets.length == 1 && targets[0] == address(this) && bytes4(payloads[0]) == this.setCouncil.selector),
+            CannotCancelCouncilRotation()
+        );
+
         // Voter-body operations are always batches scheduled with a zero predecessor (see
         // `GovernorTimelockControl._queueOperations`), so the id is reconstructed accordingly.
         operationId = _TIMELOCK.hashOperationBatch({

--- a/src/SecurityCouncil.sol
+++ b/src/SecurityCouncil.sol
@@ -126,8 +126,6 @@ contract SecurityCouncil is ISecurityCouncil {
             CannotCancelCouncilRotation()
         );
 
-        // Voter-body operations are always batches scheduled with a zero predecessor (see
-        // `GovernorTimelockControl._queueOperations`), so the id is reconstructed accordingly.
         operationId = _TIMELOCK.hashOperationBatch({
             targets: targets, values: values, payloads: payloads, predecessor: bytes32(0), salt: salt
         });

--- a/src/SecurityCouncil.sol
+++ b/src/SecurityCouncil.sol
@@ -109,7 +109,9 @@ contract SecurityCouncil is ISecurityCouncil {
         // The voter body's power to replace the council (`setCouncil`) must survive the council's brake; otherwise a
         // captured council could veto its own removal indefinitely. A `setCouncil` call is therefore the one
         // operation the council may not cancel.
-        require(!(target == address(this) && bytes4(data) == this.setCouncil.selector), CannotCancelCouncilRotation());
+        if (target == address(this) && bytes4(data) == this.setCouncil.selector) {
+            revert CannotCancelCouncilRotation();
+        }
 
         operationId =
             _TIMELOCK.hashOperation({target: target, value: value, data: data, predecessor: bytes32(0), salt: salt});
@@ -128,10 +130,9 @@ contract SecurityCouncil is ISecurityCouncil {
         // captured council could veto its own removal indefinitely. A standalone `setCouncil` call is therefore the one
         // operation the council may not cancel. Bundling it with anything else (length != 1) stays cancellable, so a
         // malicious upgrade cannot ride along under this exemption.
-        require(
-            !(targets.length == 1 && targets[0] == address(this) && bytes4(payloads[0]) == this.setCouncil.selector),
-            CannotCancelCouncilRotation()
-        );
+        if (targets.length == 1 && targets[0] == address(this) && bytes4(payloads[0]) == this.setCouncil.selector) {
+            revert CannotCancelCouncilRotation();
+        }
 
         operationId = _TIMELOCK.hashOperationBatch({
             targets: targets, values: values, payloads: payloads, predecessor: bytes32(0), salt: salt

--- a/src/interfaces/ISecurityCouncil.sol
+++ b/src/interfaces/ISecurityCouncil.sol
@@ -60,6 +60,10 @@ interface ISecurityCouncil {
     /// @notice Thrown when the implementation address supplied to `scheduleUpgrade` is zero.
     error ZeroImplementationNotAllowed();
 
+    /// @notice Thrown when the council attempts to cancel a standalone `setCouncil` rotation, which would let a
+    /// captured council veto its own replacement.
+    error CannotCancelCouncilRotation();
+
     /// @notice Schedules a token upgrade by scheduling it in the timelock.
     /// @param newImplementation The implementation to upgrade the token to.
     /// @param data The reinitialization calldata forwarded to `upgradeToAndCall` (may be empty).
@@ -74,7 +78,9 @@ interface ISecurityCouncil {
     /// @notice Cancels a queued voter-body operation in the timelock, callable only by the council. This is the
     /// council's general emergency brake: it reconstructs the operation id from the batch (all parameters are public in
     /// the timelock's `CallScheduled`/`CallSalt` events), so a voter-body upgrade cannot evade it by being bundled with
-    /// other actions. The council's propose power stays upgrades-only; this cancel power does not.
+    /// other actions. The one exception is a standalone `setCouncil` call: the council may not cancel its own
+    /// replacement, so a captured council cannot entrench itself by vetoing every rotation. The council's propose power
+    /// stays upgrades-only; this cancel power does not.
     /// @param targets The addresses the operation calls.
     /// @param values The native token values forwarded with each call.
     /// @param payloads The calldata of each call.

--- a/src/interfaces/ISecurityCouncil.sol
+++ b/src/interfaces/ISecurityCouncil.sol
@@ -75,13 +75,7 @@ interface ISecurityCouncil {
     /// @return operationId The cancelled timelock operation id.
     function cancelCouncilUpgrade() external returns (bytes32 operationId);
 
-    /// @notice Cancels a queued voter-body operation in the timelock, callable only by the council. This is the
-    /// council's general emergency brake: it reconstructs the operation id from the batch (all parameters are public in
-    /// the timelock's `CallScheduled`/`CallSalt` events), so a voter-body upgrade cannot evade it by being bundled with
-    /// other actions. The one exception is a standalone `setCouncil` call: the council may not cancel its own
-    /// replacement, so a captured council cannot entrench itself by vetoing every rotation. The council's propose power
-    /// stays upgrades-only; this cancel power does not.
-    /// @param targets The addresses the operation calls.
+    /// @notice Cancels a queued operation in the timelock.
     /// @param values The native token values forwarded with each call.
     /// @param payloads The calldata of each call.
     /// @param salt The operation salt (read from the timelock's `CallSalt` event).

--- a/src/interfaces/ISecurityCouncil.sol
+++ b/src/interfaces/ISecurityCouncil.sol
@@ -71,11 +71,18 @@ interface ISecurityCouncil {
     /// @return operationId The cancelled timelock operation id.
     function cancelCouncilUpgrade() external returns (bytes32 operationId);
 
-    /// @notice Cancels a queued governance operation in the timelock by its id, callable only by the council. This is
-    /// the council's general emergency brake: robust to any batch shape, so a voter-body upgrade cannot evade it by
-    /// being bundled with other actions. The council's propose power stays upgrades-only; this cancel power does not.
-    /// @param operationId The timelock operation id to cancel (e.g. read from the timelock's `CallScheduled` event).
-    function cancel(bytes32 operationId) external;
+    /// @notice Cancels a queued voter-body operation in the timelock, callable only by the council. This is the
+    /// council's general emergency brake: it reconstructs the operation id from the batch (all parameters are public in
+    /// the timelock's `CallScheduled`/`CallSalt` events), so a voter-body upgrade cannot evade it by being bundled with
+    /// other actions. The council's propose power stays upgrades-only; this cancel power does not.
+    /// @param targets The addresses the operation calls.
+    /// @param values The native token values forwarded with each call.
+    /// @param payloads The calldata of each call.
+    /// @param salt The operation salt (read from the timelock's `CallSalt` event).
+    /// @return operationId The cancelled timelock operation id.
+    function cancel(address[] calldata targets, uint256[] calldata values, bytes[] calldata payloads, bytes32 salt)
+        external
+        returns (bytes32 operationId);
 
     /// @notice Rotates the council address. Callable only by the timelock (a passed governance proposal), so the voter
     /// body can replace a captured or inactive council.

--- a/src/interfaces/ISecurityCouncil.sol
+++ b/src/interfaces/ISecurityCouncil.sol
@@ -15,11 +15,6 @@ interface ISecurityCouncil {
         address indexed newImplementation, bytes32 indexed operationId, bytes data, uint256 executableAt
     );
 
-    /// @notice Emitted when the council withdraws its pending upgrade.
-    /// @param operationId The cancelled timelock operation id.
-    /// @param caller The council that withdrew it.
-    event CouncilUpgradeCancelled(bytes32 indexed operationId, address indexed caller);
-
     /// @notice Emitted when the council cancels a queued governance operation in the timelock.
     /// @param operationId The cancelled timelock operation id.
     event ProposalCancelled(bytes32 indexed operationId);
@@ -37,13 +32,6 @@ interface ISecurityCouncil {
 
     /// @notice Thrown when the council schedules an upgrade while one is already pending (one upgrade in flight).
     error UpgradeAlreadyPending(bytes32 operationId);
-
-    /// @notice Thrown when a council-upgrade cancel/withdrawal is attempted but the council never scheduled one.
-    error NoUpgradeScheduled();
-
-    /// @notice Thrown when a council-upgrade cancel/withdrawal is attempted but the scheduled upgrade is no longer
-    /// pending (already executed or cancelled).
-    error UpgradeNotPending();
 
     /// @notice Thrown when the governor address supplied to the constructor is zero.
     error ZeroGovernorNotAllowed();
@@ -70,17 +58,23 @@ interface ISecurityCouncil {
     /// @return operationId The scheduled timelock operation id.
     function scheduleUpgrade(address newImplementation, bytes calldata data) external returns (bytes32 operationId);
 
-    /// @notice Withdraws the council's pending upgrade, callable only by the council. The voter body does not need
-    /// this: it cancels a council upgrade through the governor, which holds the timelock's `CANCELLER` role.
+    /// @notice Cancels a queued single-call operation in the timelock.
+    /// @param target The address the operation calls.
+    /// @param value The native token value forwarded with the call.
+    /// @param data The calldata of the call.
+    /// @param salt The operation salt (read from the timelock's `CallSalt` event).
     /// @return operationId The cancelled timelock operation id.
-    function cancelCouncilUpgrade() external returns (bytes32 operationId);
+    function cancel(address target, uint256 value, bytes calldata data, bytes32 salt)
+        external
+        returns (bytes32 operationId);
 
-    /// @notice Cancels a queued operation in the timelock.
+    /// @notice Cancels a queued batch operation in the timelock.
+    /// @param targets The addresses the operation calls.
     /// @param values The native token values forwarded with each call.
     /// @param payloads The calldata of each call.
     /// @param salt The operation salt (read from the timelock's `CallSalt` event).
     /// @return operationId The cancelled timelock operation id.
-    function cancel(address[] calldata targets, uint256[] calldata values, bytes[] calldata payloads, bytes32 salt)
+    function cancelBatch(address[] calldata targets, uint256[] calldata values, bytes[] calldata payloads, bytes32 salt)
         external
         returns (bytes32 operationId);
 

--- a/src/interfaces/ISecurityCouncil.sol
+++ b/src/interfaces/ISecurityCouncil.sol
@@ -48,8 +48,7 @@ interface ISecurityCouncil {
     /// @notice Thrown when the implementation address supplied to `scheduleUpgrade` is zero.
     error ZeroImplementationNotAllowed();
 
-    /// @notice Thrown when the council attempts to cancel a standalone `setCouncil` rotation, which would let a
-    /// captured council veto its own replacement.
+    /// @notice Thrown when the council attempts to cancel a standalone `setCouncil` rotation.
     error CannotCancelCouncilRotation();
 
     /// @notice Schedules a token upgrade by scheduling it in the timelock.

--- a/test/SecurityCouncil.t.sol
+++ b/test/SecurityCouncil.t.sol
@@ -194,9 +194,11 @@ contract SecurityCouncilTest is SecurityCouncilFixture {
         });
         assertTrue(_timelock.isOperationPending(operationId));
 
+        bytes32 salt = bytes32(bytes20(address(_governor))) ^ descriptionHash;
         vm.prank(_COUNCIL_MULTISIG);
-        _securityCouncil.cancel(operationId);
+        bytes32 cancelledId = _securityCouncil.cancel(targets, values, calldatas, salt);
 
+        assertEq(cancelledId, operationId);
         assertFalse(_timelock.isOperationPending(operationId));
     }
 
@@ -204,7 +206,8 @@ contract SecurityCouncilTest is SecurityCouncilFixture {
         address newImpl = _newImplementation();
 
         // The upgrade is bundled with a second (benign) action, so the queued operation is a multi-action batch.
-        // A reconstruction-based cancel could not match this batch's id; the general cancel by id can.
+        // The council reconstructs the batch (its parameters are public on-chain) and cancels it; bundling, and any
+        // batch shape other than a standalone `setCouncil`, stays cancellable.
         address[] memory targets = new address[](2);
         uint256[] memory values = new uint256[](2);
         bytes[] memory calldatas = new bytes[](2);
@@ -230,18 +233,61 @@ contract SecurityCouncilTest is SecurityCouncilFixture {
         });
         assertTrue(_timelock.isOperationPending(operationId));
 
+        bytes32 salt = bytes32(bytes20(address(_governor))) ^ descriptionHash;
         vm.prank(_COUNCIL_MULTISIG);
-        _securityCouncil.cancel(operationId);
+        _securityCouncil.cancel(targets, values, calldatas, salt);
 
         assertFalse(_timelock.isOperationPending(operationId));
     }
 
     function test_cancel_reverts_if_the_caller_is_not_the_council() public {
+        address[] memory targets = new address[](0);
+        uint256[] memory values = new uint256[](0);
+        bytes[] memory payloads = new bytes[](0);
         vm.expectRevert(
             abi.encodeWithSelector(ISecurityCouncil.UnauthorizedCouncil.selector, address(this)),
             address(_securityCouncil)
         );
-        _securityCouncil.cancel(bytes32(uint256(1)));
+        _securityCouncil.cancel(targets, values, payloads, bytes32(0));
+    }
+
+    /// @notice Characterizes the entrenchment vulnerability: with no guard on `cancel`, a captured council can use its
+    /// general brake to veto its own removal, so the voter body can never replace it. The follow-up fix makes the
+    /// `cancel` below revert; this test then asserts the council is removed instead.
+    function test_cancel_can_currently_veto_a_council_rotation() public {
+        // The voter body moves to replace the (captured) council with a fresh multisig: a standalone `setCouncil`.
+        address replacementCouncil = makeAddr("replacementCouncil");
+        address[] memory targets = new address[](1);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        targets[0] = address(_securityCouncil);
+        calldatas[0] = abi.encodeCall(ISecurityCouncil.setCouncil, (replacementCouncil));
+
+        string memory description = "remove the captured council";
+        bytes32 descriptionHash = keccak256(bytes(description));
+
+        vm.prank(_voter);
+        uint256 proposalId =
+            _governor.propose({targets: targets, values: values, calldatas: calldatas, description: description});
+        vm.warp(block.timestamp + _governor.votingDelay() + 1);
+        vm.prank(_voter);
+        _governor.castVote(proposalId, uint8(1));
+        vm.warp(block.timestamp + _governor.votingPeriod() + 1);
+        _governor.queue({targets: targets, values: values, calldatas: calldatas, descriptionHash: descriptionHash});
+
+        bytes32 operationId = _voterBodyOperationId({
+            targets: targets, values: values, calldatas: calldatas, descriptionHash: descriptionHash
+        });
+        bytes32 salt = bytes32(bytes20(address(_governor))) ^ descriptionHash;
+        assertTrue(_timelock.isOperationPending(operationId));
+
+        // The captured council vetoes its own removal through the general brake. Today this succeeds: the bug.
+        vm.prank(_COUNCIL_MULTISIG);
+        _securityCouncil.cancel(targets, values, calldatas, salt);
+
+        // The rotation is gone from the timelock and the council stays in control.
+        assertFalse(_timelock.isOperationPending(operationId));
+        assertEq(_securityCouncil.council(), _COUNCIL_MULTISIG);
     }
 
     function test_setCouncil_lets_the_voter_body_rotate_the_council() public {

--- a/test/SecurityCouncil.t.sol
+++ b/test/SecurityCouncil.t.sol
@@ -141,51 +141,71 @@ contract SecurityCouncilTest is SecurityCouncilFixture {
         _timelock.execute({target: target, value: 0, payload: payload, predecessor: bytes32(0), salt: salt});
     }
 
-    function test_cancelCouncilUpgrade_lets_the_council_withdraw_its_own_fast_track() public {
+    function test_cancel_lets_the_council_withdraw_its_own_fast_track() public {
         address newImpl = _newImplementation();
         vm.prank(_COUNCIL_MULTISIG);
         _securityCouncil.scheduleUpgrade(newImpl, "");
         bytes32 operationId = _securityCouncil.pendingUpgrade();
 
+        // The council's own upgrade is a single-call operation, so it withdraws it through `cancel` (not
+        // `cancelBatch`).
+        (address target, bytes memory payload, bytes32 salt) = _councilUpgradeCall(newImpl, "");
         vm.prank(_COUNCIL_MULTISIG);
-        _securityCouncil.cancelCouncilUpgrade();
+        bytes32 cancelledId = _securityCouncil.cancel({target: target, value: 0, data: payload, salt: salt});
 
+        assertEq(cancelledId, operationId);
         assertFalse(_timelock.isOperationPending(operationId));
     }
 
-    function test_cancelCouncilUpgrade_reverts_if_no_upgrade_was_ever_scheduled() public {
+    function test_cancel_reverts_if_the_operation_was_never_scheduled() public {
+        // Nothing was scheduled, so the reconstructed id matches no pending operation and the timelock rejects it.
+        address newImpl = _newImplementation();
+        (address target, bytes memory payload, bytes32 salt) = _councilUpgradeCall(newImpl, "");
+
         vm.prank(_COUNCIL_MULTISIG);
-        vm.expectRevert(ISecurityCouncil.NoUpgradeScheduled.selector, address(_securityCouncil));
-        _securityCouncil.cancelCouncilUpgrade();
+        vm.expectRevert(address(_timelock));
+        _securityCouncil.cancel({target: target, value: 0, data: payload, salt: salt});
     }
 
-    function test_cancelCouncilUpgrade_reverts_if_the_scheduled_upgrade_is_not_pending() public {
+    function test_cancel_reverts_if_the_operation_is_no_longer_pending() public {
         address newImpl = _newImplementation();
         vm.prank(_COUNCIL_MULTISIG);
         _securityCouncil.scheduleUpgrade(newImpl, "");
 
-        // Withdraw it, so `_pendingOperation` stays set but the operation is no longer pending.
+        (address target, bytes memory payload, bytes32 salt) = _councilUpgradeCall(newImpl, "");
         vm.prank(_COUNCIL_MULTISIG);
-        _securityCouncil.cancelCouncilUpgrade();
+        _securityCouncil.cancel({target: target, value: 0, data: payload, salt: salt});
 
+        // A second cancel of the same (now-cancelled) operation reverts inside the timelock.
         vm.prank(_COUNCIL_MULTISIG);
-        vm.expectRevert(ISecurityCouncil.UpgradeNotPending.selector, address(_securityCouncil));
-        _securityCouncil.cancelCouncilUpgrade();
+        vm.expectRevert(address(_timelock));
+        _securityCouncil.cancel({target: target, value: 0, data: payload, salt: salt});
     }
 
-    function test_cancelCouncilUpgrade_reverts_if_the_caller_is_not_the_council() public {
+    function test_cancel_reverts_if_the_caller_is_not_the_council() public {
         address newImpl = _newImplementation();
         vm.prank(_COUNCIL_MULTISIG);
         _securityCouncil.scheduleUpgrade(newImpl, "");
 
+        (address target, bytes memory payload, bytes32 salt) = _councilUpgradeCall(newImpl, "");
         vm.prank(_OTHER);
         vm.expectRevert(
             abi.encodeWithSelector(ISecurityCouncil.UnauthorizedCouncil.selector, _OTHER), address(_securityCouncil)
         );
-        _securityCouncil.cancelCouncilUpgrade();
+        _securityCouncil.cancel({target: target, value: 0, data: payload, salt: salt});
     }
 
-    function test_cancel_lets_the_council_cancel_a_voter_body_upgrade() public {
+    function test_cancel_cannot_be_used_to_cancel_a_setCouncil_rotation() public {
+        // The single-call `cancel` path enforces the same guard as `cancelBatch`: it refuses to cancel a `setCouncil`
+        // rotation on this module, so a captured council cannot veto its own replacement. The guard trips on the call
+        // shape alone, before any timelock lookup.
+        bytes memory data = abi.encodeCall(ISecurityCouncil.setCouncil, (makeAddr("replacementCouncil")));
+        vm.prank(_COUNCIL_MULTISIG);
+        vm.expectRevert(ISecurityCouncil.CannotCancelCouncilRotation.selector, address(_securityCouncil));
+        _securityCouncil.cancel({target: address(_securityCouncil), value: 0, data: data, salt: bytes32(0)});
+    }
+
+    function test_cancelBatch_lets_the_council_cancel_a_voter_body_upgrade() public {
         address newImpl = _newImplementation();
         (address[] memory targets, uint256[] memory values, bytes[] memory calldatas, bytes32 descriptionHash) =
             _queueVoterBodyUpgrade(newImpl);
@@ -194,9 +214,11 @@ contract SecurityCouncilTest is SecurityCouncilFixture {
         });
         assertTrue(_timelock.isOperationPending(operationId));
 
+        // Voter-body proposals are scheduled by the governor as batches with a zero predecessor.
         bytes32 salt = bytes32(bytes20(address(_governor))) ^ descriptionHash;
         vm.prank(_COUNCIL_MULTISIG);
-        bytes32 cancelledId = _securityCouncil.cancel(targets, values, calldatas, salt);
+        bytes32 cancelledId =
+            _securityCouncil.cancelBatch({targets: targets, values: values, payloads: calldatas, salt: salt});
 
         assertEq(cancelledId, operationId);
         assertFalse(_timelock.isOperationPending(operationId));
@@ -235,12 +257,12 @@ contract SecurityCouncilTest is SecurityCouncilFixture {
 
         bytes32 salt = bytes32(bytes20(address(_governor))) ^ descriptionHash;
         vm.prank(_COUNCIL_MULTISIG);
-        _securityCouncil.cancel(targets, values, calldatas, salt);
+        _securityCouncil.cancelBatch({targets: targets, values: values, payloads: calldatas, salt: salt});
 
         assertFalse(_timelock.isOperationPending(operationId));
     }
 
-    function test_cancel_reverts_if_the_caller_is_not_the_council() public {
+    function test_cancelBatch_reverts_if_the_caller_is_not_the_council() public {
         address[] memory targets = new address[](0);
         uint256[] memory values = new uint256[](0);
         bytes[] memory payloads = new bytes[](0);
@@ -248,13 +270,13 @@ contract SecurityCouncilTest is SecurityCouncilFixture {
             abi.encodeWithSelector(ISecurityCouncil.UnauthorizedCouncil.selector, address(this)),
             address(_securityCouncil)
         );
-        _securityCouncil.cancel(targets, values, payloads, bytes32(0));
+        _securityCouncil.cancelBatch({targets: targets, values: values, payloads: payloads, salt: bytes32(0)});
     }
 
     /// @notice The attack the `CannotCancelCouncilRotation` guard exists to stop: a captured council using its general
-    /// brake to veto its own removal. Without the guard, the `cancel` below succeeds, the rotation is deleted from the
-    /// timelock, and the council can repeat this on every removal attempt, entrenching itself forever.
-    function test_cancel_cannot_be_used_to_entrench_a_captured_council() public {
+    /// brake to veto its own removal. Without the guard, the `cancelBatch` below succeeds, the rotation is deleted from
+    /// the timelock, and the council can repeat this on every removal attempt, entrenching itself forever.
+    function test_cancelBatch_cannot_be_used_to_entrench_a_captured_council() public {
         // The voter body moves to replace the (captured) council with a fresh multisig: a standalone `setCouncil`.
         address replacementCouncil = makeAddr("replacementCouncil");
         address[] memory targets = new address[](1);
@@ -282,10 +304,10 @@ contract SecurityCouncilTest is SecurityCouncilFixture {
         assertTrue(_timelock.isOperationPending(operationId));
 
         // The entrenchment attempt: the captured council fires its brake at its own removal. The guard blocks it.
-        // (Delete the guard and this `cancel` succeeds, the assertion below fails, and the council survives.)
+        // (Delete the guard and this `cancelBatch` succeeds, the assertion below fails, and the council survives.)
         vm.prank(_COUNCIL_MULTISIG);
         vm.expectRevert(ISecurityCouncil.CannotCancelCouncilRotation.selector, address(_securityCouncil));
-        _securityCouncil.cancel(targets, values, calldatas, salt);
+        _securityCouncil.cancelBatch({targets: targets, values: values, payloads: calldatas, salt: salt});
 
         // The removal survives the brake and executes, replacing the council.
         assertTrue(_timelock.isOperationPending(operationId));

--- a/test/SecurityCouncil.t.sol
+++ b/test/SecurityCouncil.t.sol
@@ -251,10 +251,10 @@ contract SecurityCouncilTest is SecurityCouncilFixture {
         _securityCouncil.cancel(targets, values, payloads, bytes32(0));
     }
 
-    /// @notice Characterizes the entrenchment vulnerability: with no guard on `cancel`, a captured council can use its
-    /// general brake to veto its own removal, so the voter body can never replace it. The follow-up fix makes the
-    /// `cancel` below revert; this test then asserts the council is removed instead.
-    function test_cancel_can_currently_veto_a_council_rotation() public {
+    /// @notice The attack the `CannotCancelCouncilRotation` guard exists to stop: a captured council using its general
+    /// brake to veto its own removal. Without the guard, the `cancel` below succeeds, the rotation is deleted from the
+    /// timelock, and the council can repeat this on every removal attempt, entrenching itself forever.
+    function test_cancel_cannot_be_used_to_entrench_a_captured_council() public {
         // The voter body moves to replace the (captured) council with a fresh multisig: a standalone `setCouncil`.
         address replacementCouncil = makeAddr("replacementCouncil");
         address[] memory targets = new address[](1);
@@ -281,13 +281,26 @@ contract SecurityCouncilTest is SecurityCouncilFixture {
         bytes32 salt = bytes32(bytes20(address(_governor))) ^ descriptionHash;
         assertTrue(_timelock.isOperationPending(operationId));
 
-        // The captured council vetoes its own removal through the general brake. Today this succeeds: the bug.
+        // The entrenchment attempt: the captured council fires its brake at its own removal. The guard blocks it.
+        // (Delete the guard and this `cancel` succeeds, the assertion below fails, and the council survives.)
         vm.prank(_COUNCIL_MULTISIG);
+        vm.expectRevert(ISecurityCouncil.CannotCancelCouncilRotation.selector, address(_securityCouncil));
         _securityCouncil.cancel(targets, values, calldatas, salt);
 
-        // The rotation is gone from the timelock and the council stays in control.
-        assertFalse(_timelock.isOperationPending(operationId));
-        assertEq(_securityCouncil.council(), _COUNCIL_MULTISIG);
+        // The removal survives the brake and executes, replacing the council.
+        assertTrue(_timelock.isOperationPending(operationId));
+        skip(_timelock.getMinDelay() + 1);
+        _governor.execute({targets: targets, values: values, calldatas: calldatas, descriptionHash: descriptionHash});
+        assertEq(_securityCouncil.council(), replacementCouncil);
+
+        // The ousted council is now powerless: its privileged entry points reject it.
+        address newImpl = _newImplementation();
+        vm.prank(_COUNCIL_MULTISIG);
+        vm.expectRevert(
+            abi.encodeWithSelector(ISecurityCouncil.UnauthorizedCouncil.selector, _COUNCIL_MULTISIG),
+            address(_securityCouncil)
+        );
+        _securityCouncil.scheduleUpgrade(newImpl, "");
     }
 
     function test_setCouncil_lets_the_voter_body_rotate_the_council() public {

--- a/test/SecurityCouncil.t.sol
+++ b/test/SecurityCouncil.t.sol
@@ -276,7 +276,7 @@ contract SecurityCouncilTest is SecurityCouncilFixture {
     /// @notice The attack the `CannotCancelCouncilRotation` guard exists to stop: a captured council using its general
     /// brake to veto its own removal. Without the guard, the `cancelBatch` below succeeds, the rotation is deleted from
     /// the timelock, and the council can repeat this on every removal attempt, entrenching itself forever.
-    function test_cancelBatch_cannot_be_used_to_entrench_a_captured_council() public {
+    function test_cancelBatch_cannot_be_used_to_cancel_a_setCouncil_rotation() public {
         // The voter body moves to replace the (captured) council with a fresh multisig: a standalone `setCouncil`.
         address replacementCouncil = makeAddr("replacementCouncil");
         address[] memory targets = new address[](1);


### PR DESCRIPTION
A captured security council could use its general timelock brake (`cancel`) to veto the `setCouncil` proposal that would replace it, and repeat that on every attempt, so the voter body could never remove it.

This makes `cancel` operation-aware: it takes the operation's `(targets, values, payloads, salt)` and reconstructs the timelock id, then reverts on a standalone `setCouncil` call (the council's own-removal path). Every other operation, including a malicious upgrade bundled with other actions, stays cancellable.

Two commits, test then fix: the first characterizes the vulnerability with a test that is green on the old behavior, the second adds the guard and flips the test to assert the council is removed instead.

Considered a time-box variant (`cancel` only delays an op, never kills it) for a guarantee covering every removal path, but kept the surgical carve-out so the council retains a real hard veto against a malicious majority.
