### PR TITLE
refactor: replace if-revert with require in XanV2 drafts

### DIFF
--- a/src/drafts/XanV2.sol
+++ b/src/drafts/XanV2.sol
@@ -83,9 +83,7 @@ contract XanV2 is IXanV2, XanV1 {
 
     /// @notice Throws if the sender is not the forwarder.
     function _checkForwarder() internal view {
-        if (forwarder() != _msgSender()) {
-            revert UnauthorizedCaller({caller: _msgSender()});
-        }
+        require(forwarder() == _msgSender(), UnauthorizedCaller({caller: _msgSender()}));
     }
 
     /// @notice Returns the storage from the Xan V2 storage location.

--- a/src/drafts/XanV2Forwarder.sol
+++ b/src/drafts/XanV2Forwarder.sol
@@ -25,12 +25,8 @@ contract XanV2Forwarder {
     /// @param calldataCarrierLogicRef The logic reference of the associated calldata carrier resource.
     constructor(address xanProxy, address protocolAdapter, bytes32 calldataCarrierLogicRef) {
         // Zero checks
-        if (xanProxy == address(0) || protocolAdapter == address(0)) {
-            revert AddressZero();
-        }
-        if (calldataCarrierLogicRef == bytes32(0)) {
-            revert Bytes32Zero();
-        }
+        require(xanProxy != address(0) && protocolAdapter != address(0), AddressZero());
+        require(calldataCarrierLogicRef != bytes32(0), Bytes32Zero());
 
         _XAN_PROXY = XanV2(xanProxy);
         _PROTOCOL_ADAPTER = protocolAdapter;
@@ -44,23 +40,19 @@ contract XanV2Forwarder {
     /// @param input The `bytes` encoded mint calldata (including the `bytes4` function selector).
     /// @return output The empty output of the call.
     function forwardCall(bytes calldata input) external returns (bytes memory output) {
-        if (msg.sender != _PROTOCOL_ADAPTER) {
-            revert UnauthorizedCaller(msg.sender);
-        }
+        require(msg.sender == _PROTOCOL_ADAPTER, UnauthorizedCaller(msg.sender));
 
         bytes4 selector = bytes4(input[:4]);
 
         bytes memory args = input[4:];
 
         // Check that that the mint function is the call target.
-        if (selector != XanV2.mint.selector) {
-            revert InvalidFunctionSelector({expected: XanV2.mint.selector, actual: selector});
-        }
+        require(
+            selector == XanV2.mint.selector, InvalidFunctionSelector({expected: XanV2.mint.selector, actual: selector})
+        );
         // NOTE: The recipient address is not needed on the EVM side, because the forwarder receives the tokens.
         (address recipient, uint256 value) = abi.decode(args, (address, uint256));
-        if (recipient == address(this)) {
-            revert InvalidMintRecipient({recipient: address(this)});
-        }
+        require(recipient != address(this), InvalidMintRecipient({recipient: address(this)}));
 
         output = bytes("");
 


### PR DESCRIPTION
Partially addresses #92 by switching the if-revert-error pattern to require(condition, CustomError()) in the XanV2 draft contracts (XanV2.sol, XanV2Forwarder.sol). solc 0.8.35 supports custom errors in require since 0.8.27.

XanV1 is intentionally left untouched, so #92 stays open for the rest until the last moment before deploying V2.

All 109 tests pass.

Refs #92