### PR TITLE
test: cover XanGovernor lifecycle and trim redundant tests

### DIFF
--- a/test/XanGovernor.proposal.sol
+++ b/test/XanGovernor.proposal.sol
@@ -47,6 +47,20 @@ contract XanGovernorProposalTest is XanGovernorFixture {
         assertEq(uint8(_governor.state(proposalId)), uint8(IGovernor.ProposalState.Canceled));
     }
 
+    function test_cancel_reverts_for_pending_proposals_if_the_caller_is_not_the_proposer() public {
+        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) = _noopProposal();
+        vm.prank(_voter);
+        uint256 proposalId = _governor.propose(targets, values, calldatas, "cancel me");
+        assertEq(uint8(_governor.state(proposalId)), uint8(IGovernor.ProposalState.Pending));
+
+        // Cancellation is only allowed by the proposer while the proposal is still pending (before voting opens).
+        vm.prank(_OTHER);
+        vm.expectRevert(
+            abi.encodeWithSelector(IGovernor.GovernorUnableToCancel.selector, proposalId, _OTHER), address(_governor)
+        );
+        _governor.cancel(targets, values, calldatas, keccak256(bytes("cancel me")));
+    }
+
     function test_quorum_is_half_of_the_voting_supply() public view {
         // The fixture reuses the V1 ratio (50%); the whole supply is the voting supply, so quorum is half of it.
         assertEq(_QUORUM_NUMERATOR, 50);

--- a/test/XanGovernor.proposal.sol
+++ b/test/XanGovernor.proposal.sol
@@ -10,7 +10,7 @@ import {XanGovernorFixture} from "./XanGovernorFixture.sol";
 /// @notice Covers the governor's configuration getters and the proposal cancellation path: proposal creation is gated
 /// by the threshold, quorum tracks the configured supply fraction, timelock proposals report as needing queuing, and a
 /// proposer can withdraw a still-pending proposal.
-contract XanGovernorProposalLifecycleTest is XanGovernorFixture {
+contract XanGovernorProposalTest is XanGovernorFixture {
     function test_proposalThreshold_gates_proposal_creation() public {
         assertEq(_governor.proposalThreshold(), _PROPOSAL_THRESHOLD);
 

--- a/test/XanGovernor.proposal.sol
+++ b/test/XanGovernor.proposal.sol
@@ -26,7 +26,7 @@ contract XanGovernorProposalTest is XanGovernorFixture {
         _governor.propose(targets, values, calldatas, "below threshold");
     }
 
-    function test_proposalNeedsQueuing_is_true_for_the_timelock_governor() public {
+    function test_proposalNeedsQueuing_returns_true_for_proposals() public {
         (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) = _noopProposal();
         vm.prank(_voter);
         uint256 proposalId = _governor.propose(targets, values, calldatas, "needs queuing");
@@ -35,7 +35,7 @@ contract XanGovernorProposalTest is XanGovernorFixture {
         assertTrue(_governor.proposalNeedsQueuing(proposalId));
     }
 
-    function test_proposer_can_cancel_a_pending_proposal() public {
+    function test_cancel_cancels_pending_proposals_if_called_by_the_proposer() public {
         (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) = _noopProposal();
         vm.prank(_voter);
         uint256 proposalId = _governor.propose(targets, values, calldatas, "cancel me");

--- a/test/XanGovernor.proposalLifecycle.t.sol
+++ b/test/XanGovernor.proposalLifecycle.t.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.30;
+
+import {IGovernor} from "@openzeppelin/contracts/governance/IGovernor.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {Parameters} from "../src/libs/Parameters.sol";
+import {XanGovernorFixture} from "./XanGovernorFixture.sol";
+
+/// @notice Covers the governor's configuration getters and the proposal cancellation path: proposal creation is gated
+/// by the threshold, quorum tracks the configured supply fraction, timelock proposals report as needing queuing, and a
+/// proposer can withdraw a still-pending proposal.
+contract XanGovernorProposalLifecycleTest is XanGovernorFixture {
+    function test_proposalThreshold_gates_proposal_creation() public {
+        assertEq(_governor.proposalThreshold(), _PROPOSAL_THRESHOLD);
+
+        // `_OTHER` holds no voting power, so it is below the threshold and cannot open a proposal.
+        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) = _noopProposal();
+        vm.prank(_OTHER);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IGovernor.GovernorInsufficientProposerVotes.selector, _OTHER, 0, _PROPOSAL_THRESHOLD
+            ),
+            address(_governor)
+        );
+        _governor.propose(targets, values, calldatas, "below threshold");
+    }
+
+    function test_proposalNeedsQueuing_is_true_for_the_timelock_governor() public {
+        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) = _noopProposal();
+        vm.prank(_voter);
+        uint256 proposalId = _governor.propose(targets, values, calldatas, "needs queuing");
+
+        // Every accepted proposal must pass through the timelock before it can be executed.
+        assertTrue(_governor.proposalNeedsQueuing(proposalId));
+    }
+
+    function test_proposer_can_cancel_a_pending_proposal() public {
+        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) = _noopProposal();
+        vm.prank(_voter);
+        uint256 proposalId = _governor.propose(targets, values, calldatas, "cancel me");
+        assertEq(uint8(_governor.state(proposalId)), uint8(IGovernor.ProposalState.Pending));
+
+        // Cancellation is only allowed by the proposer while the proposal is still pending (before voting opens).
+        vm.prank(_voter);
+        _governor.cancel(targets, values, calldatas, keccak256(bytes("cancel me")));
+        assertEq(uint8(_governor.state(proposalId)), uint8(IGovernor.ProposalState.Canceled));
+    }
+
+    function test_quorum_is_half_of_the_voting_supply() public view {
+        // The fixture reuses the V1 ratio (50%); the whole supply is the voting supply, so quorum is half of it.
+        assertEq(_QUORUM_NUMERATOR, 50);
+        assertEq(_governor.quorum(block.timestamp - 1), Parameters.SUPPLY / 2);
+    }
+
+    /// @notice A minimal, harmless single-call proposal used only to drive lifecycle transitions.
+    function _noopProposal()
+        internal
+        view
+        returns (address[] memory targets, uint256[] memory values, bytes[] memory calldatas)
+    {
+        targets = new address[](1);
+        targets[0] = address(_xanToken);
+        values = new uint256[](1);
+        calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeCall(IERC20.transfer, (_OTHER, 0));
+    }
+}

--- a/test/XanGovernor.proposalLifecycle.t.sol
+++ b/test/XanGovernor.proposalLifecycle.t.sol
@@ -31,7 +31,7 @@ contract XanGovernorProposalLifecycleTest is XanGovernorFixture {
         vm.prank(_voter);
         uint256 proposalId = _governor.propose(targets, values, calldatas, "needs queuing");
 
-        // Every accepted proposal must pass through the timelock before it can be executed.
+        // This timelock governor requires every proposal to queue before it can be executed.
         assertTrue(_governor.proposalNeedsQueuing(proposalId));
     }
 

--- a/test/XanGovernorFixture.sol
+++ b/test/XanGovernorFixture.sol
@@ -21,7 +21,7 @@ abstract contract XanGovernorFixture is Test {
     uint48 internal constant _VOTING_DELAY = 1;
     /// @notice Voting period in seconds.
     uint32 internal constant _VOTING_PERIOD = 50;
-    /// @notice No voting power is required to create a proposal in this example.
+    /// @notice Voting power required to create a proposal.
     uint256 internal constant _PROPOSAL_THRESHOLD = 1 ether;
     /// @notice Quorum as a percentage of the voting supply, reusing the V1 quorum ratio (50%). `GovernorVotesQuorumFraction`
     /// uses a denominator of 100, so the V1 ratio is rescaled from its denominator of `QUORUM_RATIO_DENOMINATOR`.
@@ -40,8 +40,6 @@ abstract contract XanGovernorFixture is Test {
 
     /// @notice The account that received the initial mint and holds the entire voting supply.
     address internal _voter;
-    /// @notice An unprivileged account used for negative checks.
-    address internal _other;
 
     function setUp() public virtual {
         (, _voter,) = vm.readCallers();

--- a/test/XanSecurityCouncil.t.sol
+++ b/test/XanSecurityCouncil.t.sol
@@ -137,6 +137,41 @@ contract XanSecurityCouncilTest is XanSecurityCouncilFixture {
         assertEq(_xanToken.implementation(), newImpl);
     }
 
+    function test_scheduleUpgrade_forwards_the_reinitialization_data() public {
+        address newImpl = _newImplementation();
+        // A non-empty reinitialization payload forwarded to `upgradeToAndCall`.
+        bytes memory data = abi.encodeWithSelector(_xanToken.clock.selector);
+
+        // The data is part of the salt, so the same upgrade with data has a different operation id than without it.
+        (address emptyTarget, bytes memory emptyPayload, bytes32 emptySalt) = _councilUpgradeCall(newImpl, "");
+        bytes32 emptyId = _timelock.hashOperation({
+            target: emptyTarget, value: 0, data: emptyPayload, predecessor: bytes32(0), salt: emptySalt
+        });
+        (address target, bytes memory payload, bytes32 salt) = _councilUpgradeCall(newImpl, data);
+        bytes32 expectedId =
+            _timelock.hashOperation({target: target, value: 0, data: payload, predecessor: bytes32(0), salt: salt});
+        assertTrue(expectedId != emptyId);
+
+        // The event carries the forwarded calldata verbatim.
+        vm.expectEmit(address(_securityCouncil));
+        emit IXanSecurityCouncil.UpgradeScheduled({
+            newImplementation: newImpl,
+            operationId: expectedId,
+            data: data,
+            executableAt: block.timestamp + _securityCouncil.cancelWindow()
+        });
+
+        vm.prank(_COUNCIL_MULTISIG);
+        bytes32 operationId = _securityCouncil.scheduleUpgrade(newImpl, data);
+        assertEq(operationId, expectedId);
+
+        // Execution forwards `data` to `upgradeToAndCall`, so the upgrade applies and the payload runs without
+        // reverting.
+        skip(_securityCouncil.cancelWindow() + 1);
+        _timelock.execute({target: target, value: 0, payload: payload, predecessor: bytes32(0), salt: salt});
+        assertEq(_xanToken.implementation(), newImpl);
+    }
+
     function test_scheduleUpgrade_cannot_be_executed_before_the_delay() public {
         address newImpl = _newImplementation();
         vm.prank(_COUNCIL_MULTISIG);

--- a/test/XanSecurityCouncil.t.sol
+++ b/test/XanSecurityCouncil.t.sol
@@ -95,6 +95,16 @@ contract XanSecurityCouncilTest is XanSecurityCouncilFixture {
     function test_scheduleUpgrade_lets_the_council_fast_track_an_upgrade() public {
         address newImpl = _newImplementation();
 
+        (address target, bytes memory payload, bytes32 salt) = _councilUpgradeCall(newImpl, "");
+        bytes32 expectedId =
+            _timelock.hashOperation({target: target, value: 0, data: payload, predecessor: bytes32(0), salt: salt});
+        uint256 executableAt = block.timestamp + _securityCouncil.cancelWindow();
+
+        vm.expectEmit(address(_securityCouncil));
+        emit IXanSecurityCouncil.UpgradeScheduled({
+            newImplementation: newImpl, operationId: expectedId, data: "", executableAt: executableAt
+        });
+
         vm.prank(_COUNCIL_MULTISIG);
         _securityCouncil.scheduleUpgrade(newImpl, "");
 
@@ -151,6 +161,10 @@ contract XanSecurityCouncilTest is XanSecurityCouncilFixture {
         // The council's own upgrade is a single-call operation, so it withdraws it through `cancel` (not
         // `cancelBatch`).
         (address target, bytes memory payload, bytes32 salt) = _councilUpgradeCall(newImpl, "");
+
+        vm.expectEmit(address(_securityCouncil));
+        emit IXanSecurityCouncil.ProposalCancelled(operationId);
+
         vm.prank(_COUNCIL_MULTISIG);
         bytes32 cancelledId = _securityCouncil.cancel({target: target, value: 0, data: payload, salt: salt});
 
@@ -311,6 +325,10 @@ contract XanSecurityCouncilTest is XanSecurityCouncilFixture {
 
     function test_setCouncil_lets_the_voter_body_rotate_the_council() public {
         address newCouncil = makeAddr("newCouncil");
+
+        vm.expectEmit(address(_securityCouncil));
+        emit IXanSecurityCouncil.CouncilChanged({previousCouncil: _COUNCIL_MULTISIG, newCouncil: newCouncil});
+
         vm.prank(address(_timelock));
         _securityCouncil.setCouncil(newCouncil);
         assertEq(_securityCouncil.council(), newCouncil);

--- a/test/XanSecurityCouncil.t.sol
+++ b/test/XanSecurityCouncil.t.sol
@@ -229,16 +229,6 @@ contract XanSecurityCouncilTest is XanSecurityCouncilFixture {
         assertFalse(_timelock.isOperationPending(operationId));
     }
 
-    function test_cancel_reverts_if_the_operation_was_never_scheduled() public {
-        // Nothing was scheduled, so the reconstructed id matches no pending operation and the timelock rejects it.
-        address newImpl = _newImplementation();
-        (address target, bytes memory payload, bytes32 salt) = _councilUpgradeCall(newImpl, "");
-
-        vm.prank(_COUNCIL_MULTISIG);
-        vm.expectRevert(address(_timelock));
-        _securityCouncil.cancel({target: target, value: 0, data: payload, salt: salt});
-    }
-
     function test_cancel_reverts_if_the_operation_is_no_longer_pending() public {
         address newImpl = _newImplementation();
         vm.prank(_COUNCIL_MULTISIG);
@@ -293,36 +283,6 @@ contract XanSecurityCouncilTest is XanSecurityCouncilFixture {
         });
 
         assertEq(cancelledId, operationId);
-        assertFalse(_timelock.isOperationPending(operationId));
-    }
-
-    function test_cancelBatch_cancels_a_voter_body_upgrade_bundled_with_other_actions() public {
-        address newImpl = _newImplementation();
-
-        // The upgrade is bundled with a second (benign) action, so the queued operation is a multi-action batch.
-        // The council reconstructs the batch (its parameters are public on-chain) and cancels it; bundling, and any
-        // batch shape other than a standalone `setCouncil`, stays cancellable.
-        address[] memory targets = new address[](2);
-        uint256[] memory values = new uint256[](2);
-        bytes[] memory calldatas = new bytes[](2);
-        targets[0] = _OTHER;
-        calldatas[0] = "";
-        targets[1] = address(_xanToken);
-        calldatas[1] = abi.encodeCall(UUPSUpgradeable.upgradeToAndCall, (newImpl, ""));
-
-        bytes32 descriptionHash =
-            _queueVoterBodyProposal(targets, values, calldatas, "upgrade bundled with another action");
-
-        bytes32 operationId = _voterBodyOperationId({
-            targets: targets, values: values, calldatas: calldatas, descriptionHash: descriptionHash
-        });
-        assertTrue(_timelock.isOperationPending(operationId));
-
-        vm.prank(_COUNCIL_MULTISIG);
-        _securityCouncil.cancelBatch({
-            targets: targets, values: values, payloads: calldatas, salt: _voterBodySalt(descriptionHash)
-        });
-
         assertFalse(_timelock.isOperationPending(operationId));
     }
 

--- a/test/XanSecurityCouncil.t.sol
+++ b/test/XanSecurityCouncil.t.sol
@@ -92,6 +92,28 @@ contract XanSecurityCouncilTest is XanSecurityCouncilFixture {
         _securityCouncil.scheduleUpgrade(second, "");
     }
 
+    function test_scheduleUpgrade_can_be_rescheduled_after_a_cancel() public {
+        address newImpl = _newImplementation();
+
+        vm.prank(_COUNCIL_MULTISIG);
+        _securityCouncil.scheduleUpgrade(newImpl, "");
+        bytes32 firstId = _securityCouncil.pendingUpgrade();
+
+        // Withdraw the upgrade, clearing the in-flight slot.
+        (address target, bytes memory payload, bytes32 salt) = _councilUpgradeCall(newImpl, "");
+        vm.prank(_COUNCIL_MULTISIG);
+        _securityCouncil.cancel({target: target, value: 0, data: payload, salt: salt});
+        assertFalse(_timelock.isOperationPending(firstId));
+
+        // The cancelled operation is no longer pending, so the same upgrade re-schedules: this exercises the
+        // `!isOperationPending` branch of the in-flight guard (the first schedule took the `== bytes32(0)` branch).
+        // The deterministic salt makes the re-scheduled id identical to the first.
+        vm.prank(_COUNCIL_MULTISIG);
+        bytes32 secondId = _securityCouncil.scheduleUpgrade(newImpl, "");
+        assertEq(secondId, firstId);
+        assertTrue(_timelock.isOperationPending(secondId));
+    }
+
     function test_scheduleUpgrade_lets_the_council_fast_track_an_upgrade() public {
         address newImpl = _newImplementation();
 

--- a/test/XanSecurityCouncil.t.sol
+++ b/test/XanSecurityCouncil.t.sol
@@ -325,6 +325,37 @@ contract XanSecurityCouncilTest is XanSecurityCouncilFixture {
         assertFalse(_timelock.isOperationPending(operationId));
     }
 
+    function test_cancelBatch_can_cancel_a_setCouncil_bundled_with_an_upgrade() public {
+        // A standalone `setCouncil` is the one operation the council may not cancel. Bundling it with a second action
+        // (here a token upgrade) makes the batch length != 1, so the exemption does not apply and the whole batch
+        // stays cancellable: a malicious upgrade cannot shield itself by riding along with a rotation.
+        address newImpl = _newImplementation();
+        address replacementCouncil = makeAddr("replacementCouncil");
+
+        address[] memory targets = new address[](2);
+        uint256[] memory values = new uint256[](2);
+        bytes[] memory calldatas = new bytes[](2);
+        targets[0] = address(_securityCouncil);
+        calldatas[0] = abi.encodeCall(IXanSecurityCouncil.setCouncil, (replacementCouncil));
+        targets[1] = address(_xanToken);
+        calldatas[1] = abi.encodeCall(UUPSUpgradeable.upgradeToAndCall, (newImpl, ""));
+
+        bytes32 descriptionHash =
+            _queueVoterBodyProposal(targets, values, calldatas, "rotation bundled with an upgrade");
+        bytes32 operationId = _voterBodyOperationId({
+            targets: targets, values: values, calldatas: calldatas, descriptionHash: descriptionHash
+        });
+        assertTrue(_timelock.isOperationPending(operationId));
+
+        vm.prank(_COUNCIL_MULTISIG);
+        bytes32 cancelledId = _securityCouncil.cancelBatch({
+            targets: targets, values: values, payloads: calldatas, salt: _voterBodySalt(descriptionHash)
+        });
+
+        assertEq(cancelledId, operationId);
+        assertFalse(_timelock.isOperationPending(operationId));
+    }
+
     function test_cancelBatch_reverts_if_the_caller_is_not_the_council() public {
         address[] memory targets = new address[](0);
         uint256[] memory values = new uint256[](0);

--- a/test/XanSecurityCouncil.t.sol
+++ b/test/XanSecurityCouncil.t.sol
@@ -268,9 +268,10 @@ contract XanSecurityCouncilTest is XanSecurityCouncilFixture {
     }
 
     function test_cancel_cannot_be_used_to_cancel_a_setCouncil_rotation() public {
-        // The single-call `cancel` path enforces the same guard as `cancelBatch`: it refuses to cancel a `setCouncil`
-        // rotation on this module, so a captured council cannot veto its own replacement. The guard trips on the call
-        // shape alone, before any timelock lookup.
+        // Defense-in-depth mirror of the `cancelBatch` guard: the single-call `cancel` also refuses a `setCouncil`
+        // rotation on this module. A real voter-body rotation is a governor *batch* (cancellable only via
+        // `cancelBatch`), so the single path could never match its id anyway; this guard is belt-and-suspenders. It
+        // trips on the call shape alone, before any timelock lookup.
         bytes memory data = abi.encodeCall(IXanSecurityCouncil.setCouncil, (makeAddr("replacementCouncil")));
         vm.prank(_COUNCIL_MULTISIG);
         vm.expectRevert(IXanSecurityCouncil.CannotCancelCouncilRotation.selector, address(_securityCouncil));


### PR DESCRIPTION
Adds proposal-lifecycle coverage for XanGovernor. proposalThreshold, quorum, proposalNeedsQueuing and the proposal-cancellation path had no tests; this brings the governor to full function coverage.

Also tidies the XanSecurityCouncil suite: drops two tests that only duplicated existing coverage (a cancel of a never-scheduled op, already covered by the no-longer-pending case; and a bundled-batch cancel already covered by the setCouncil-plus-upgrade batch test), and rescopes the single-call cancel guard comment to note it is defense-in-depth behind the cancelBatch guard.

Test-only, on top of feature/example-governor.
