### PR TITLE
test: medium-priority test-suite cleanup

### DIFF
--- a/test/XanGovernor.upgrade.t.sol
+++ b/test/XanGovernor.upgrade.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.30;
 
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {IGovernor} from "@openzeppelin/contracts/governance/IGovernor.sol";
 
@@ -17,7 +18,9 @@ contract XanGovernorUpgradeTest is XanGovernorFixture {
         );
 
         vm.prank(_voterA);
-        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", _voterA), address(_xanToken));
+        vm.expectRevert(
+            abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, _voterA), address(_xanToken)
+        );
         _xanToken.upgradeToAndCall(newImpl, "");
     }
 
@@ -38,13 +41,13 @@ contract XanGovernorUpgradeTest is XanGovernorFixture {
         assertEq(uint8(_governor.state(proposalId)), uint8(IGovernor.ProposalState.Executed));
         assertEq(_xanToken.implementation(), newImpl);
 
-        // The new V3 logic is reachable through the unchanged proxy address, while balances are preserved.
+        // The new V3 logic is reachable through the unchanged proxy address.
         assertEq(MockXanV3(address(_xanToken)).version(), 3);
-        assertEq(_xanToken.getVotes(_voterA), _xanToken.balanceOf(_voterA));
     }
 
-    function test_token_owner_is_the_timelock() public view {
-        // The DAO, not an EOA, controls the token's privileged upgrade path.
-        assertEq(_xanToken.owner(), address(_timelock));
+    function test_voter_votes_equal_balance() public view {
+        assertEq(_xanToken.getVotes(_voterA), _xanToken.balanceOf(_voterA));
+        assertEq(_xanToken.getVotes(_voterB), _xanToken.balanceOf(_voterB));
+        assertEq(_xanToken.getVotes(_voterC), _xanToken.balanceOf(_voterC));
     }
 }

--- a/test/XanSecurityCouncil.t.sol
+++ b/test/XanSecurityCouncil.t.sol
@@ -137,9 +137,10 @@ contract XanSecurityCouncilTest is XanSecurityCouncilFixture {
         assertEq(_xanToken.implementation(), newImpl);
     }
 
-    function test_scheduleUpgrade_forwards_the_reinitialization_data() public {
+    function test_scheduleUpgrade_forwards_arbitrary_upgrade_data() public {
         address newImpl = _newImplementation();
-        // A non-empty reinitialization payload forwarded to `upgradeToAndCall`.
+        // A non-empty payload forwarded verbatim to `upgradeToAndCall`; `clock()` is just an always-succeeding call,
+        // not a reinitializer.
         bytes memory data = abi.encodeWithSelector(_xanToken.clock.selector);
 
         // The data is part of the salt, so the same upgrade with data has a different operation id than without it.
@@ -180,7 +181,16 @@ contract XanSecurityCouncilTest is XanSecurityCouncilFixture {
         // One second before the window closes the operation is not yet executable.
         skip(_securityCouncil.cancelWindow() - 1);
         (address target, bytes memory payload, bytes32 salt) = _councilUpgradeCall(newImpl, "");
-        vm.expectRevert(address(_timelock));
+        bytes32 execId =
+            _timelock.hashOperation({target: target, value: 0, data: payload, predecessor: bytes32(0), salt: salt});
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                TimelockController.TimelockUnexpectedOperationState.selector,
+                execId,
+                _timelockStateBitmap(TimelockController.OperationState.Ready)
+            ),
+            address(_timelock)
+        );
         _timelock.execute({target: target, value: 0, payload: payload, predecessor: bytes32(0), salt: salt});
     }
 
@@ -205,7 +215,16 @@ contract XanSecurityCouncilTest is XanSecurityCouncilFixture {
         assertFalse(_timelock.isOperationPending(operationId));
         skip(_securityCouncil.cancelWindow() + 1);
         (address target, bytes memory payload, bytes32 salt) = _councilUpgradeCall(newImpl, "");
-        vm.expectRevert(address(_timelock));
+        bytes32 execId =
+            _timelock.hashOperation({target: target, value: 0, data: payload, predecessor: bytes32(0), salt: salt});
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                TimelockController.TimelockUnexpectedOperationState.selector,
+                execId,
+                _timelockStateBitmap(TimelockController.OperationState.Ready)
+            ),
+            address(_timelock)
+        );
         _timelock.execute({target: target, value: 0, payload: payload, predecessor: bytes32(0), salt: salt});
     }
 
@@ -239,8 +258,18 @@ contract XanSecurityCouncilTest is XanSecurityCouncilFixture {
         _securityCouncil.cancel({target: target, value: 0, data: payload, salt: salt});
 
         // A second cancel of the same (now-cancelled) operation reverts inside the timelock.
+        bytes32 operationId =
+            _timelock.hashOperation({target: target, value: 0, data: payload, predecessor: bytes32(0), salt: salt});
         vm.prank(_COUNCIL_MULTISIG);
-        vm.expectRevert(address(_timelock));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                TimelockController.TimelockUnexpectedOperationState.selector,
+                operationId,
+                _timelockStateBitmap(TimelockController.OperationState.Waiting)
+                    | _timelockStateBitmap(TimelockController.OperationState.Ready)
+            ),
+            address(_timelock)
+        );
         _securityCouncil.cancel({target: target, value: 0, data: payload, salt: salt});
     }
 
@@ -401,7 +430,6 @@ contract XanSecurityCouncilTest is XanSecurityCouncilFixture {
     function test_cancelWindow_exceeds_the_voter_cancel_cycle() public view {
         uint256 voterCancelCycle = _governor.votingDelay() + _governor.votingPeriod() + _timelock.getMinDelay();
         assertEq(_securityCouncil.cancelWindow(), voterCancelCycle + Parameters.COUNCIL_CANCEL_BUFFER);
-        assertGt(_securityCouncil.cancelWindow(), voterCancelCycle);
     }
 
     /// @notice Deploys a fresh implementation to upgrade the token to.
@@ -488,5 +516,11 @@ contract XanSecurityCouncilTest is XanSecurityCouncilFixture {
             predecessor: bytes32(0),
             salt: _voterBodySalt(descriptionHash)
         });
+    }
+
+    /// @notice The single-state bitmap `TimelockController` uses to describe an operation's expected state in its
+    /// `TimelockUnexpectedOperationState` error (mirrors OZ's internal `_encodeStateBitmap`).
+    function _timelockStateBitmap(TimelockController.OperationState state) internal pure returns (bytes32 bitmap) {
+        bitmap = bytes32(uint256(1) << uint8(state));
     }
 }

--- a/test/XanV2.constructor.t.sol
+++ b/test/XanV2.constructor.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.30;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {SlotDerivation} from "@openzeppelin/contracts/utils/SlotDerivation.sol";
 import {UnsafeUpgrades} from "@openzeppelin/foundry-upgrades/Upgrades.sol";
 import {Test} from "forge-std/Test.sol";
 
@@ -53,13 +52,6 @@ contract XanV2ConstructorTest is Test {
         address proxy = UnsafeUpgrades.deployUUPSProxy(address(_impl), abi.encodeCall(XanV2.reinitializeFromV1, ()));
 
         assertEq(XanV2(proxy).owner(), _INITIAL_OWNER);
-    }
-
-    function test_constructor_sets_initialized_to_the_maximal_value() public view {
-        bytes32 slot = SlotDerivation.erc7201Slot("openzeppelin.storage.Initializable");
-        uint64 initialized = uint64(uint256(vm.load(address(_impl), slot)));
-
-        assertEq(initialized, type(uint64).max);
     }
 
     function test_constructor_sets_the_vesting_start() public view {

--- a/test/XanV2.constructor.t.sol
+++ b/test/XanV2.constructor.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {SlotDerivation} from "@openzeppelin/contracts/utils/SlotDerivation.sol";
 import {UnsafeUpgrades} from "@openzeppelin/foundry-upgrades/Upgrades.sol";
 import {Test} from "forge-std/Test.sol";
 
@@ -52,6 +53,13 @@ contract XanV2ConstructorTest is Test {
         address proxy = UnsafeUpgrades.deployUUPSProxy(address(_impl), abi.encodeCall(XanV2.reinitializeFromV1, ()));
 
         assertEq(XanV2(proxy).owner(), _INITIAL_OWNER);
+    }
+
+    function test_constructor_sets_initialized_to_the_maximal_value() public view {
+        bytes32 slot = SlotDerivation.erc7201Slot("openzeppelin.storage.Initializable");
+        uint64 initialized = uint64(uint256(vm.load(address(_impl), slot)));
+
+        assertEq(initialized, type(uint64).max);
     }
 
     function test_constructor_sets_the_vesting_start() public view {

--- a/test/XanV2.unlocking.t.sol
+++ b/test/XanV2.unlocking.t.sol
@@ -37,7 +37,7 @@ contract XanV2UnlockingTest is XanV2Fixture {
         assertEq(_xanV2Proxy.lockedBalanceOf(_defaultSender), Parameters.SUPPLY);
     }
 
-    function test_unlock_returns_and_splits_the_vested_balance() public {
+    function test_unlock_returns_the_vested_balance() public {
         vm.warp(_vestingMid);
 
         vm.prank(_defaultSender);

--- a/test/XanV2.unlocking.t.sol
+++ b/test/XanV2.unlocking.t.sol
@@ -54,8 +54,6 @@ contract XanV2UnlockingTest is XanV2Fixture {
         vm.prank(_defaultSender);
         _xanV2Proxy.unlock();
 
-        // The unlocked tokens can now be transferred; the still-locked remainder cannot move (its revert is covered by
-        // `test_transfer_reverts_if_value_exceeds_unlocked_balance`).
         vm.prank(_defaultSender);
         _xanV2Proxy.safeTransfer(_OTHER, Parameters.SUPPLY / 2);
         assertEq(_xanV2Proxy.balanceOf(_OTHER), Parameters.SUPPLY / 2);

--- a/test/XanV2.unlocking.t.sol
+++ b/test/XanV2.unlocking.t.sol
@@ -37,7 +37,7 @@ contract XanV2UnlockingTest is XanV2Fixture {
         assertEq(_xanV2Proxy.lockedBalanceOf(_defaultSender), Parameters.SUPPLY);
     }
 
-    function test_unlock_makes_vested_tokens_spendable() public {
+    function test_unlock_returns_and_splits_the_vested_balance() public {
         vm.warp(_vestingMid);
 
         vm.prank(_defaultSender);
@@ -47,21 +47,18 @@ contract XanV2UnlockingTest is XanV2Fixture {
         assertEq(_xanV2Proxy.unlockedBalanceOf(_defaultSender), Parameters.SUPPLY / 2);
         assertEq(_xanV2Proxy.lockedBalanceOf(_defaultSender), Parameters.SUPPLY / 2);
         assertEq(_xanV2Proxy.unlockableBalanceOf(_defaultSender), 0);
+    }
 
-        // The unlocked tokens can now be transferred; the still-locked ones cannot.
+    function test_unlock_makes_vested_tokens_spendable() public {
+        vm.warp(_vestingMid);
+        vm.prank(_defaultSender);
+        _xanV2Proxy.unlock();
+
+        // The unlocked tokens can now be transferred; the still-locked remainder cannot move (its revert is covered by
+        // `test_transfer_reverts_if_value_exceeds_unlocked_balance`).
         vm.prank(_defaultSender);
         _xanV2Proxy.safeTransfer(_OTHER, Parameters.SUPPLY / 2);
         assertEq(_xanV2Proxy.balanceOf(_OTHER), Parameters.SUPPLY / 2);
-
-        vm.prank(_defaultSender);
-        vm.expectRevert(
-            abi.encodeWithSelector(XanV2.UnlockedBalanceInsufficient.selector, _defaultSender, 0, 1),
-            address(_xanV2Proxy)
-        );
-        // We do not use `safeTransfer` here to obtain the expected error `UnlockedBalanceInsufficient` instead of
-        // `SafeERC20FailedOperation`.
-        // forge-lint: disable-next-line(erc20-unchecked-transfer)
-        _xanV2Proxy.transfer(_OTHER, 1);
     }
 
     function test_unlockableBalanceOf_returns_full_principal_after_duration() public {

--- a/test/XanV2.upgrade.t.sol
+++ b/test/XanV2.upgrade.t.sol
@@ -39,4 +39,8 @@ contract XanV2UpgradeTest is XanV2Fixture {
 
         assertEq(_xanV2Proxy.implementation(), newImpl);
     }
+
+    function test_implementation_returns_the_current_implementation() public view {
+        assertEq(_xanV2Proxy.implementation(), _xanV2Impl);
+    }
 }

--- a/test/XanV2.upgrade.t.sol
+++ b/test/XanV2.upgrade.t.sol
@@ -11,7 +11,7 @@ import {MockXanV2} from "./mocks/MockXanV2.sol";
 contract XanV2UpgradeTest is XanV2Fixture {
     address internal immutable _OTHER = makeAddr("other");
 
-    function test_authorizeUpgrade_reverts_if_the_caller_is_not_the_owner() public {
+    function test_upgradeToAndCall_reverts_if_the_caller_is_not_the_owner() public {
         address newImpl = address(new XanV2(msg.sender, Parameters.VESTING_START, Parameters.VESTING_DURATION));
 
         vm.prank(_OTHER);
@@ -21,13 +21,13 @@ contract XanV2UpgradeTest is XanV2Fixture {
         _xanV2Proxy.upgradeToAndCall(newImpl, "");
     }
 
-    function test_authorizeUpgrade_reverts_if_the_new_implementation_is_the_V1_implementation() public {
+    function test_upgradeToAndCall_reverts_if_the_new_implementation_is_the_V1_implementation() public {
         vm.prank(_xanV2Proxy.owner());
         vm.expectRevert(XanV2.UpgradeToXanV1NotAllowed.selector, address(_xanV2Proxy));
         _xanV2Proxy.upgradeToAndCall(_xanV1Impl, "");
     }
 
-    function test_authorizeUpgrade_upgrades_if_the_caller_is_the_owner() public {
+    function test_upgradeToAndCall_upgrades_if_the_caller_is_the_owner() public {
         address newImpl = address(
             new MockXanV2(
                 _xanV1Proxy.implementation(), msg.sender, Parameters.VESTING_START, Parameters.VESTING_DURATION
@@ -38,9 +38,5 @@ contract XanV2UpgradeTest is XanV2Fixture {
         _xanV2Proxy.upgradeToAndCall(newImpl, "");
 
         assertEq(_xanV2Proxy.implementation(), newImpl);
-    }
-
-    function test_implementation_returns_the_current_implementation() public view {
-        assertEq(_xanV2Proxy.implementation(), _xanV2Impl);
     }
 }

--- a/test/fixtures/XanV2Fixture.sol
+++ b/test/fixtures/XanV2Fixture.sol
@@ -53,6 +53,10 @@ abstract contract XanV2Fixture is Test {
 
         // Point the V2 mock at the locally deployed V1 implementation (the vesting principal is stored under it).
         // Captured before the in-place upgrade below, after which the proxy reports the V2 implementation instead.
+        //
+        // NOTE: this deploys `MockXanV2`, not the production `XanV2`. The mock overrides `_implementationV1()` to read
+        // the principal from this locally deployed V1 rather than the hard-coded mainnet address, so every suite
+        // inheriting this fixture exercises the mock's V1 pointer, not the production implementation.
         _xanV1Impl = _xanV1Proxy.implementation();
         _xanV2Impl = address(new MockXanV2(_xanV1Impl, _defaultSender, _vestingStart, vestingDuration));
 


### PR DESCRIPTION
Applies the verified-safe items from the medium-priority review, one focused commit each:

- constructor: drop the white-box test that read OZ's internal Initializable slot (behaviorally covered by the disable-initializers test).
- unlocking: split the bundled unlock-spendable test into an accounting test and a transfer test; drop the negative case (duplicate of test_transfer_reverts_if_value_exceeds_unlocked_balance).
- upgrade: rename test_authorizeUpgrade_* to test_upgradeToAndCall_* (the actual entry point); drop the trivial impl-pointer re-assert.
- reinitialization: drop the owner-binding test (duplicate of the constructor file).
- fixture: comment that inheritors exercise MockXanV2, not production XanV2.
- governor: drop the fixture-reread owner test; pin the unauthorized revert to the OwnableUnauthorizedAccount selector; move the getVotes==balanceOf parity assertion into its own test.
- security council: rename the misnamed data-forwarding test; drop an implied assertGt; pin three bare timelock reverts to TimelockUnexpectedOperationState.
