### PR TITLE
fix: disable renounceOwnership on the upgrade council

### DIFF
--- a/src/XanUpgradeCouncil.sol
+++ b/src/XanUpgradeCouncil.sol
@@ -135,6 +135,14 @@ contract XanUpgradeCouncil is IXanUpgradeCouncil, Ownable {
         delay = _GOVERNOR.votingDelay() + _GOVERNOR.votingPeriod() + _TIMELOCK.getMinDelay() + _CANCEL_BUFFER;
     }
 
+    /// @notice Renouncing ownership is disabled.
+    /// @dev The timelock's ownership is the voter body's only lever to rotate a captured or inactive council;
+    /// renouncing would set the owner to `address(0)`, permanently disabling `setCouncil` and freezing the current
+    /// council. Reverts unconditionally.
+    function renounceOwnership() public pure override {
+        revert RenouncingOwnershipDisabled();
+    }
+
     /// @notice Deterministic, council-tagged salt so a council upgrade never collides with a voter-body operation and
     /// can be re-scheduled after a cancel.
     /// @param newImplementation The implementation to upgrade the token to.

--- a/src/interfaces/IXanUpgradeCouncil.sol
+++ b/src/interfaces/IXanUpgradeCouncil.sol
@@ -45,6 +45,10 @@ interface IXanUpgradeCouncil {
     /// @notice Thrown when `cancelUpgrade` is called but no council upgrade is pending in the timelock.
     error NoUpgradePending();
 
+    /// @notice Thrown when `renounceOwnership` is called; renouncing is disabled so the voter body always retains the
+    /// timelock's ownership lever to rotate the council.
+    error RenouncingOwnershipDisabled();
+
     /// @notice Schedules a token upgrade by scheduling it in the timelock.
     /// @param newImplementation The implementation to upgrade the token to.
     /// @param data The reinitialization calldata forwarded to `upgradeToAndCall` (may be empty).

--- a/test/XanUpgradeCouncil.t.sol
+++ b/test/XanUpgradeCouncil.t.sol
@@ -445,6 +445,14 @@ contract XanUpgradeCouncilTest is XanUpgradeCouncilFixture {
         _upgradeCouncil.setCouncil(address(0));
     }
 
+    /// @notice Renouncing ownership is disabled: it would zero the owner and permanently freeze `setCouncil`,
+    /// destroying the voter body's power to rotate a captured or inactive council.
+    function test_renounceOwnership_is_disabled() public {
+        vm.prank(address(_timelock));
+        vm.expectRevert(IXanUpgradeCouncil.RenouncingOwnershipDisabled.selector, address(_upgradeCouncil));
+        _upgradeCouncil.renounceOwnership();
+    }
+
     function test_constructor_sets_the_timelock_as_owner_and_the_multisig_as_council() public view {
         assertEq(_upgradeCouncil.owner(), address(_timelock));
         assertEq(_upgradeCouncil.council(), _COUNCIL_MULTISIG);


### PR DESCRIPTION
`Ownable` from #118 also gives us a public `renounceOwnership`. The timelock owns the council, so a passed proposal could renounce it, and then `setCouncil` is dead for good and the current council can never be rotated. Override it to revert.