### PR TITLE
refactor: align deploy-script error naming and headers

### DIFF
--- a/script/DeployXanV1.s.sol
+++ b/script/DeployXanV1.s.sol
@@ -8,6 +8,8 @@ import {Script} from "forge-std/Script.sol";
 
 import {XanV1} from "../src/XanV1.sol";
 
+/// @notice Deploys the XanV1 implementation behind a UUPS proxy and initializes it with the initial mint recipient
+/// (the token distributor) and the governance council.
 contract DeployXanV1 is Script {
     function run(address initialMintRecipient, address council) public returns (address proxy, address implementation) {
         vm.startBroadcast();

--- a/script/ExecuteXanV2Upgrade.s.sol
+++ b/script/ExecuteXanV2Upgrade.s.sol
@@ -10,6 +10,8 @@ import {Script} from "forge-std/Script.sol";
 import {XanV1} from "../src/XanV1.sol";
 import {XanV2} from "../src/XanV2.sol";
 
+/// @notice Permissionlessly executes a council-scheduled XanV1 to XanV2 upgrade once the delay has ended, running
+/// `upgradeToAndCall` with the argument-free `reinitializeFromV1`.
 contract ExecuteXanV2Upgrade is Script {
     error ZeroImplementationV2NotAllowed();
 

--- a/script/PrepareXanV2Upgrade.s.sol
+++ b/script/PrepareXanV2Upgrade.s.sol
@@ -17,8 +17,8 @@ import {XanUpgradeCouncilModule} from "../src/XanUpgradeCouncilModule.sol";
 /// governance council is a multisig, so it must execute `scheduleCouncilUpgrade(implV2)` itself using the returned
 /// `implV2`.
 contract PrepareXanV2Upgrade is Script {
-    error InvalidTokenAddress();
-    error InvalidCouncilAddress();
+    error ZeroTokenNotAllowed();
+    error ZeroCouncilNotAllowed();
 
     /// @notice Deploys the governance stack and prepares the XanV1 to V2 upgrade implementation.
     /// @param proxy The XanV1 proxy to upgrade.
@@ -65,8 +65,8 @@ contract PrepareXanV2Upgrade is Script {
         public
         returns (address governor, address timelock, address councilModule)
     {
-        require(token != address(0), InvalidTokenAddress());
-        require(councilMultisig != address(0), InvalidCouncilAddress());
+        require(token != address(0), ZeroTokenNotAllowed());
+        require(councilMultisig != address(0), ZeroCouncilNotAllowed());
 
         // 1. The timelock owns the token and executes accepted proposals.
         // The caller (`msg.sender`) is a temporary admin so the roles below can be wired; the timelock also

--- a/test/script/PrepareXanV2Upgrade.t.sol
+++ b/test/script/PrepareXanV2Upgrade.t.sol
@@ -45,12 +45,12 @@ contract PrepareXanV2UpgradeTest is Test {
     }
 
     function test_deployGovernance_reverts_if_the_token_is_the_zero_address() public {
-        vm.expectRevert(PrepareXanV2Upgrade.InvalidTokenAddress.selector, address(_script));
+        vm.expectRevert(PrepareXanV2Upgrade.ZeroTokenNotAllowed.selector, address(_script));
         _script.deployGovernance({token: address(0), councilMultisig: _COUNCIL_MULTISIG});
     }
 
     function test_deployGovernance_reverts_if_the_council_is_the_zero_address() public {
-        vm.expectRevert(PrepareXanV2Upgrade.InvalidCouncilAddress.selector, address(_script));
+        vm.expectRevert(PrepareXanV2Upgrade.ZeroCouncilNotAllowed.selector, address(_script));
         _script.deployGovernance({token: _token, councilMultisig: address(0)});
     }
 


### PR DESCRIPTION
* `PrepareXanV2Upgrade` used `Invalid*Address` errors while every contract (and `ExecuteXanV2Upgrade`) follows the `Zero*NotAllowed` convention for zero-address guards — rename to match.
* Give `DeployXanV1` the `@notice` header its sibling scripts have.