### PR TITLE
refactor: rename getPendingUpgradeOperationId to getLastScheduledUpgradeOperationId

### DIFF
--- a/src/XanUpgradeCouncilModule.sol
+++ b/src/XanUpgradeCouncilModule.sol
@@ -33,7 +33,7 @@ contract XanUpgradeCouncilModule is IXanUpgradeCouncilModule {
     uint256 private immutable _EXTRA_DELAY;
 
     /// @notice The most recently scheduled council upgrade operation id.
-    bytes32 private _pendingUpgradeOperationId;
+    bytes32 private _lastScheduledUpgradeOperationId;
 
     /// @notice Thrown when a council-only function is called by another account.
     error UnauthorizedCouncil(address caller);
@@ -101,8 +101,9 @@ contract XanUpgradeCouncilModule is IXanUpgradeCouncilModule {
         require(newImplementation != address(0), ZeroImplementationNotAllowed());
         // One council upgrade in flight at a time.
         require(
-            _pendingUpgradeOperationId == bytes32(0) || !_TIMELOCK.isOperationPending(_pendingUpgradeOperationId),
-            UpgradeAlreadyPending(_pendingUpgradeOperationId)
+            _lastScheduledUpgradeOperationId == bytes32(0)
+                || !_TIMELOCK.isOperationPending(_lastScheduledUpgradeOperationId),
+            UpgradeAlreadyPending(_lastScheduledUpgradeOperationId)
         );
 
         bytes memory call = abi.encodeCall(UUPSUpgradeable.upgradeToAndCall, (newImplementation, data));
@@ -111,7 +112,7 @@ contract XanUpgradeCouncilModule is IXanUpgradeCouncilModule {
 
         operationId =
             _TIMELOCK.hashOperation({target: _TOKEN, value: 0, data: call, predecessor: bytes32(0), salt: salt});
-        _pendingUpgradeOperationId = operationId;
+        _lastScheduledUpgradeOperationId = operationId;
 
         emit UpgradeScheduled(newImplementation, operationId, data, block.timestamp + delay);
 
@@ -122,7 +123,7 @@ contract XanUpgradeCouncilModule is IXanUpgradeCouncilModule {
     /// @dev Callable only by the council. The module only ever aims the timelock's `CANCELLER` role at the operation
     /// it scheduled itself, so the council has no cancel power over voter-body operations.
     function cancelUpgrade() external override onlyCouncil returns (bytes32 operationId) {
-        operationId = _pendingUpgradeOperationId;
+        operationId = _lastScheduledUpgradeOperationId;
         require(operationId != bytes32(0) && _TIMELOCK.isOperationPending(operationId), NoUpgradePending());
 
         emit UpgradeCancelled(operationId);
@@ -156,14 +157,8 @@ contract XanUpgradeCouncilModule is IXanUpgradeCouncilModule {
     }
 
     /// @inheritdoc IXanUpgradeCouncilModule
-    function getPendingUpgradeOperationId() external view override returns (bytes32 operationId) {
-        operationId = _pendingUpgradeOperationId;
-
-        // The module tracks the most recently scheduled operation; report it only while it is still pending in the
-        // timelock so the getter's name holds (an executed or cancelled upgrade is no longer pending).
-        if (operationId != bytes32(0) && !_TIMELOCK.isOperationPending(operationId)) {
-            operationId = bytes32(0);
-        }
+    function getLastScheduledUpgradeOperationId() external view override returns (bytes32 operationId) {
+        operationId = _lastScheduledUpgradeOperationId;
     }
 
     /// @inheritdoc IXanUpgradeCouncilModule

--- a/src/XanUpgradeCouncilModule.sol
+++ b/src/XanUpgradeCouncilModule.sol
@@ -158,6 +158,12 @@ contract XanUpgradeCouncilModule is IXanUpgradeCouncilModule {
     /// @inheritdoc IXanUpgradeCouncilModule
     function getPendingUpgradeOperationId() external view override returns (bytes32 operationId) {
         operationId = _pendingUpgradeOperationId;
+
+        // The module tracks the most recently scheduled operation; report it only while it is still pending in the
+        // timelock so the getter's name holds (an executed or cancelled upgrade is no longer pending).
+        if (operationId != bytes32(0) && !_TIMELOCK.isOperationPending(operationId)) {
+            operationId = bytes32(0);
+        }
     }
 
     /// @inheritdoc IXanUpgradeCouncilModule

--- a/src/interfaces/IXanUpgradeCouncilModule.sol
+++ b/src/interfaces/IXanUpgradeCouncilModule.sol
@@ -51,7 +51,7 @@ interface IXanUpgradeCouncilModule {
 
     /// @notice Returns the most recently scheduled council upgrade operation id (may already be executed or
     /// cancelled).
-    /// @return operationId The tracked operation id, or zero if no council upgrade was ever scheduled.
+    /// @return operationId The last scheduled upgrade operation id, or zero if no council upgrade was ever scheduled.
     function getLastScheduledUpgradeOperationId() external view returns (bytes32 operationId);
 
     /// @notice Returns the timelock delay a scheduled council upgrade waits out before anyone can execute it. It

--- a/src/interfaces/IXanUpgradeCouncilModule.sol
+++ b/src/interfaces/IXanUpgradeCouncilModule.sol
@@ -49,9 +49,10 @@ interface IXanUpgradeCouncilModule {
     /// @return extraDelay The extra delay in seconds.
     function getExtraDelay() external view returns (uint256 extraDelay);
 
-    /// @notice Returns the operation id of the council upgrade currently pending in the timelock.
-    /// @return operationId The pending operation id, or zero if no council upgrade is pending.
-    function getPendingUpgradeOperationId() external view returns (bytes32 operationId);
+    /// @notice Returns the most recently scheduled council upgrade operation id (may already be executed or
+    /// cancelled).
+    /// @return operationId The tracked operation id, or zero if no council upgrade was ever scheduled.
+    function getLastScheduledUpgradeOperationId() external view returns (bytes32 operationId);
 
     /// @notice Returns the timelock delay a scheduled council upgrade waits out before anyone can execute it. It
     /// exceeds a full voter-cancel cycle, so the voter body can always cancel the upgrade first.

--- a/src/interfaces/IXanUpgradeCouncilModule.sol
+++ b/src/interfaces/IXanUpgradeCouncilModule.sol
@@ -49,9 +49,8 @@ interface IXanUpgradeCouncilModule {
     /// @return extraDelay The extra delay in seconds.
     function getExtraDelay() external view returns (uint256 extraDelay);
 
-    /// @notice Returns the most recently scheduled council upgrade operation id (may already be executed or
-    /// cancelled).
-    /// @return operationId The tracked operation id.
+    /// @notice Returns the operation id of the council upgrade currently pending in the timelock.
+    /// @return operationId The pending operation id, or zero if no council upgrade is pending.
     function getPendingUpgradeOperationId() external view returns (bytes32 operationId);
 
     /// @notice Returns the timelock delay a scheduled council upgrade waits out before anyone can execute it. It

--- a/test/XanUpgradeCouncilModule.t.sol
+++ b/test/XanUpgradeCouncilModule.t.sol
@@ -393,6 +393,40 @@ contract XanUpgradeCouncilModuleTest is XanUpgradeCouncilModuleFixture {
         assertEq(_module.upgradeDelay(), upgradeDelayBefore + periodBefore);
     }
 
+    function test_getPendingUpgradeOperationId_returns_the_operation_id_while_the_upgrade_is_pending() public {
+        address newImpl = _newImplementation();
+        vm.prank(_COUNCIL_MULTISIG);
+        bytes32 operationId = _module.scheduleUpgrade(newImpl, "");
+
+        assertEq(_module.getPendingUpgradeOperationId(), operationId);
+
+        // Still pending right up to execution, even after the cancel window has elapsed.
+        skip(_module.upgradeDelay() + 1);
+        assertEq(_module.getPendingUpgradeOperationId(), operationId);
+    }
+
+    function test_getPendingUpgradeOperationId_returns_zero_after_a_cancel() public {
+        address newImpl = _newImplementation();
+        vm.prank(_COUNCIL_MULTISIG);
+        _module.scheduleUpgrade(newImpl, "");
+
+        vm.prank(_COUNCIL_MULTISIG);
+        _module.cancelUpgrade();
+
+        assertEq(_module.getPendingUpgradeOperationId(), bytes32(0));
+    }
+
+    function test_getPendingUpgradeOperationId_returns_zero_after_execution() public {
+        address newImpl = _newImplementation();
+        vm.prank(_COUNCIL_MULTISIG);
+        _module.scheduleUpgrade(newImpl, "");
+
+        skip(_module.upgradeDelay() + 1);
+        _executeCouncilUpgrade(newImpl, "");
+
+        assertEq(_module.getPendingUpgradeOperationId(), bytes32(0));
+    }
+
     function test_constructor_sets_the_timelock() public view {
         assertEq(_module.getTimelock(), address(_timelock));
     }
@@ -411,6 +445,10 @@ contract XanUpgradeCouncilModuleTest is XanUpgradeCouncilModuleFixture {
 
     function test_constructor_sets_the_extra_delay() public view {
         assertEq(_module.getExtraDelay(), Parameters.COUNCIL_EXTRA_DELAY);
+    }
+
+    function test_getPendingUpgradeOperationId_returns_zero_if_nothing_was_scheduled() public view {
+        assertEq(_module.getPendingUpgradeOperationId(), bytes32(0));
     }
 
     function test_upgradeDelay_exceeds_the_voter_cancel_cycle() public view {

--- a/test/XanUpgradeCouncilModule.t.sol
+++ b/test/XanUpgradeCouncilModule.t.sol
@@ -97,7 +97,7 @@ contract XanUpgradeCouncilModuleTest is XanUpgradeCouncilModuleFixture {
         vm.prank(_COUNCIL_MULTISIG);
         _module.scheduleUpgrade(first, "");
 
-        bytes32 pending = _module.getPendingUpgradeOperationId();
+        bytes32 pending = _module.getLastScheduledUpgradeOperationId();
         vm.prank(_COUNCIL_MULTISIG);
         vm.expectRevert(
             abi.encodeWithSelector(XanUpgradeCouncilModule.UpgradeAlreadyPending.selector, pending), address(_module)
@@ -110,7 +110,7 @@ contract XanUpgradeCouncilModuleTest is XanUpgradeCouncilModuleFixture {
 
         vm.prank(_COUNCIL_MULTISIG);
         _module.scheduleUpgrade(newImpl, "");
-        bytes32 firstId = _module.getPendingUpgradeOperationId();
+        bytes32 firstId = _module.getLastScheduledUpgradeOperationId();
 
         // Withdraw the upgrade, clearing the in-flight slot.
         vm.prank(_COUNCIL_MULTISIG);
@@ -210,7 +210,7 @@ contract XanUpgradeCouncilModuleTest is XanUpgradeCouncilModuleFixture {
         address newImpl = _newImplementation();
         vm.prank(_COUNCIL_MULTISIG);
         _module.scheduleUpgrade(newImpl, "");
-        bytes32 operationId = _module.getPendingUpgradeOperationId();
+        bytes32 operationId = _module.getLastScheduledUpgradeOperationId();
 
         address[] memory targets = new address[](1);
         uint256[] memory values = new uint256[](1);
@@ -244,7 +244,7 @@ contract XanUpgradeCouncilModuleTest is XanUpgradeCouncilModuleFixture {
         address newImpl = _newImplementation();
         vm.prank(_COUNCIL_MULTISIG);
         _module.scheduleUpgrade(newImpl, "");
-        bytes32 operationId = _module.getPendingUpgradeOperationId();
+        bytes32 operationId = _module.getLastScheduledUpgradeOperationId();
 
         vm.expectEmit(address(_module));
         emit IXanUpgradeCouncilModule.UpgradeCancelled(operationId);
@@ -393,38 +393,39 @@ contract XanUpgradeCouncilModuleTest is XanUpgradeCouncilModuleFixture {
         assertEq(_module.upgradeDelay(), upgradeDelayBefore + periodBefore);
     }
 
-    function test_getPendingUpgradeOperationId_returns_the_operation_id_while_the_upgrade_is_pending() public {
+    function test_getLastScheduledUpgradeOperationId_returns_the_operation_id_while_the_upgrade_is_pending() public {
         address newImpl = _newImplementation();
         vm.prank(_COUNCIL_MULTISIG);
         bytes32 operationId = _module.scheduleUpgrade(newImpl, "");
 
-        assertEq(_module.getPendingUpgradeOperationId(), operationId);
+        assertEq(_module.getLastScheduledUpgradeOperationId(), operationId);
 
-        // Still pending right up to execution, even after the cancel window has elapsed.
+        // Still tracked right up to execution, even after the upgrade delay has elapsed.
         skip(_module.upgradeDelay() + 1);
-        assertEq(_module.getPendingUpgradeOperationId(), operationId);
+        assertEq(_module.getLastScheduledUpgradeOperationId(), operationId);
     }
 
-    function test_getPendingUpgradeOperationId_returns_zero_after_a_cancel() public {
+    function test_getLastScheduledUpgradeOperationId_still_returns_the_id_after_a_cancel() public {
         address newImpl = _newImplementation();
         vm.prank(_COUNCIL_MULTISIG);
-        _module.scheduleUpgrade(newImpl, "");
+        bytes32 operationId = _module.scheduleUpgrade(newImpl, "");
 
         vm.prank(_COUNCIL_MULTISIG);
         _module.cancelUpgrade();
 
-        assertEq(_module.getPendingUpgradeOperationId(), bytes32(0));
+        // The getter reports the tracked id regardless of timelock state; callers check pending state themselves.
+        assertEq(_module.getLastScheduledUpgradeOperationId(), operationId);
     }
 
-    function test_getPendingUpgradeOperationId_returns_zero_after_execution() public {
+    function test_getLastScheduledUpgradeOperationId_still_returns_the_id_after_execution() public {
         address newImpl = _newImplementation();
         vm.prank(_COUNCIL_MULTISIG);
-        _module.scheduleUpgrade(newImpl, "");
+        bytes32 operationId = _module.scheduleUpgrade(newImpl, "");
 
         skip(_module.upgradeDelay() + 1);
         _executeCouncilUpgrade(newImpl, "");
 
-        assertEq(_module.getPendingUpgradeOperationId(), bytes32(0));
+        assertEq(_module.getLastScheduledUpgradeOperationId(), operationId);
     }
 
     function test_constructor_sets_the_timelock() public view {
@@ -447,8 +448,8 @@ contract XanUpgradeCouncilModuleTest is XanUpgradeCouncilModuleFixture {
         assertEq(_module.getExtraDelay(), Parameters.COUNCIL_EXTRA_DELAY);
     }
 
-    function test_getPendingUpgradeOperationId_returns_zero_if_nothing_was_scheduled() public view {
-        assertEq(_module.getPendingUpgradeOperationId(), bytes32(0));
+    function test_getLastScheduledUpgradeOperationId_returns_zero_if_nothing_was_scheduled() public view {
+        assertEq(_module.getLastScheduledUpgradeOperationId(), bytes32(0));
     }
 
     function test_upgradeDelay_exceeds_the_voter_cancel_cycle() public view {


### PR DESCRIPTION
The getter returned the most recently scheduled operation id even after that upgrade had been executed or cancelled, contradicting its name. Rather than filtering on timelock state on every call, rename the storage variable and getter to what they actually track: the last scheduled operation, pending or not. Callers check pending state themselves via the timelock.