### PR TITLE
test: cover proposer-suffix front-running protection

### DIFF
--- a/test/XanGovernor.security.t.sol
+++ b/test/XanGovernor.security.t.sol
@@ -6,12 +6,14 @@ import {
 } from "@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFraction.sol";
 import {IGovernor} from "@openzeppelin/contracts/governance/IGovernor.sol";
 import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import {XanGovernorFixture} from "./fixtures/XanGovernorFixture.sol";
 
 /// @notice Pins the governance-only gates the layer's security rests on: `relay` (the voter body's instrument for
 /// cancelling council upgrades), the governor's settings, and the timelock's delay are reachable only through a
-/// passed proposal — never directly.
+/// passed proposal — never directly. Also pins the opt-in `#proposer=` front-running protection on `propose`
+/// (see `docs/02-XanV2-governance.md` section 3).
 contract XanGovernorSecurityTest is XanGovernorFixture {
     function test_relay_reverts_if_not_called_through_governance() public {
         // `relay` fronts the voter body's cancel of a council upgrade (`relay -> timelock.cancel`); outside a passed
@@ -58,5 +60,57 @@ contract XanGovernorSecurityTest is XanGovernorFixture {
         _passProposal({targets: targets, values: values, calldatas: calldatas, description: "lower the quorum to 30%"});
 
         assertEq(_governor.quorumNumerator(), 30);
+    }
+
+    /// @dev Pins the front-running risk documented in `docs/02-XanV2-governance.md` section 3: without a
+    /// `#proposer=` suffix, `propose` is unrestricted, so another eligible account can submit the identical payload
+    /// first, become the recorded proposer, and cancel it while pending.
+    function test_propose_without_proposer_suffix_can_be_frontrun() public {
+        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) = _noopProposal();
+        string memory description = "no suffix";
+
+        // `_voterB` front-runs `_voterA`'s identical proposal.
+        vm.prank(_voterB);
+        uint256 proposalId = _governor.propose(targets, values, calldatas, description);
+
+        // `_voterA`'s own submission now reverts: the operation already exists under the same id.
+        vm.prank(_voterA);
+        vm.expectRevert();
+        _governor.propose(targets, values, calldatas, description);
+
+        // `_voterB`, as the recorded proposer, cancels it while pending; `_voterA` never got a say.
+        vm.prank(_voterB);
+        _governor.cancel(targets, values, calldatas, keccak256(bytes(description)));
+        assertEq(uint8(_governor.state(proposalId)), uint8(IGovernor.ProposalState.Canceled));
+    }
+
+    /// @dev Pins the mitigation from the same doc section: a `#proposer=0x<address>` suffix restricts submission to
+    /// that address, so the front-run in the test above is blocked.
+    function test_propose_with_proposer_suffix_blocks_frontrunning() public {
+        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) = _noopProposal();
+        string memory description = string.concat("with suffix#proposer=", vm.toString(_voterA));
+
+        vm.prank(_voterB);
+        vm.expectRevert(
+            abi.encodeWithSelector(IGovernor.GovernorRestrictedProposer.selector, _voterB), address(_governor)
+        );
+        _governor.propose(targets, values, calldatas, description);
+
+        // The named proposer is unaffected.
+        vm.prank(_voterA);
+        _governor.propose(targets, values, calldatas, description);
+    }
+
+    /// @notice A minimal, harmless single-call proposal used only to drive lifecycle transitions.
+    function _noopProposal()
+        internal
+        view
+        returns (address[] memory targets, uint256[] memory values, bytes[] memory calldatas)
+    {
+        targets = new address[](1);
+        targets[0] = address(_xanToken);
+        values = new uint256[](1);
+        calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeCall(IERC20.transfer, (_OTHER, 0));
     }
 }


### PR DESCRIPTION
docs/02-XanV2-governance.md documents that propose() without a #proposer= suffix can be front-run: another eligible account can submit the identical payload first, become the recorded proposer, and cancel it while pending. No test exercised that claim or its mitigation, so this adds two to XanGovernor.security.t.sol: one showing the front-run succeeds without the suffix, one showing it's blocked with it.