### PR TITLE
doc: record the delay-decrease gap while a council upgrade is pending

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -39,7 +39,7 @@ flowchart LR
 
 - **Two upgrade paths**, both ending as a timelocked upgrade: a **voter-body proposal**, or a **council-initiated upgrade**. The council path is _slower_, not faster — it waits out a longer delay than a voter proposal, so the voter body always has time to cancel it.
 - **One-way cancel**: the voter body can cancel the council's upgrade through a governor proposal, and the council can withdraw its own pending upgrade — but the council cannot cancel voter-body operations. Cancelling only blocks — no funds can move this way.
-- **Voter supremacy**: the voter body can cancel the council's upgrades, replace the council, and revoke the module's powers; the council holds no reciprocal check over the voter body. The one gap is an **inactive voter body** — the scenario the council exists for — where the council's long delay and off-chain monitoring are the only checks.
+- **Voter supremacy**: the voter body can cancel the council's upgrades, replace the council, and revoke the module's powers; the council holds no reciprocal check over the voter body. The irreducible gap is an **inactive voter body** — the scenario the council exists for — where the council's long delay and off-chain monitoring are the only checks. A second, operational one: leaving two contrary timing-settings proposals queued in the timelock lets a pending council upgrade's deadline be pushed out and pulled back, stranding a cancel filed in between — see [Settings changes while an upgrade is pending](docs/02-XanV2-governance.md#settings-changes-while-an-upgrade-is-pending).
 
 ## Glossary
 

--- a/docs/02-XanV2-governance.md
+++ b/docs/02-XanV2-governance.md
@@ -73,7 +73,7 @@ upgradeDelay = votingDelay + votingPeriod + timelock.getMinDelay() + COUNCIL_EXT
 
 With the parameters in the [Parameters](#9-parameters) section this is `7d + 14d + 14d + 7d = 42 days`.
 
-**Recomputation at execution.** The timelock stores a scheduled operation as a fixed timestamp and never consults the governor again, while a cancellation computes its cycle live, when the cancelling proposal is created. A settings raise landing _after_ an upgrade was scheduled would therefore stretch every later cancel cycle past a deadline that no longer moves — and the council can arrange exactly that, because `Governor.execute` is permissionless, so it can schedule an upgrade and execute an already-passed, ripe raise in the same transaction.
+**Recomputation at execution.** The timelock stores a scheduled operation as a fixed timestamp and never consults the governor again, while a cancellation computes its cycle live, when the cancelling proposal is created. A delay increase landing _after_ an upgrade was scheduled would therefore stretch every later cancel cycle past a deadline that no longer moves — and the council can arrange exactly that, because `Governor.execute` is permissionless, so it can schedule an upgrade and execute an already-passed, ready delay increase in the same transaction.
 
 The module closes this by scheduling each upgrade as a **two-call batch**:
 
@@ -82,7 +82,7 @@ The module closes this by scheduling each upgrade as a **two-call batch**:
 | 1   | `module.checkUpgradeDelayElapsed(scheduledAt)` | Reverts unless `now ≥ scheduledAt + upgradeDelay()`, **recomputed from the current settings** |
 | 2   | `token.upgradeToAndCall(newImpl, data)`        | The upgrade itself                                                                            |
 
-`TimelockController.executeBatch` runs the calls in order and reverts the whole execution if one fails, so a reverting `checkUpgradeDelayElapsed` blocks the upgrade; because the operation is only marked done after every call succeeds, it stays `Ready` and a later attempt still works. The effective deadline is therefore the **later** of the timelock's frozen timestamp and the recomputed `scheduledAt + upgradeDelay()`: a raise pushes it out, a cut cannot pull it in. Since `checkUpgradeDelayElapsed` tests the recomputed cycle _plus_ `COUNCIL_EXTRA_DELAY`, and a cancellation takes the recomputed cycle, the voter body keeps its full margin whatever the settings do — no bound on how far they may move is required.
+`TimelockController.executeBatch` runs the calls in order and reverts the whole execution if one fails, so a reverting `checkUpgradeDelayElapsed` blocks the upgrade; because the operation is only marked done after every call succeeds, it stays `Ready` and a later attempt still works. The effective deadline is therefore the **later** of the timelock's frozen timestamp and the recomputed `scheduledAt + upgradeDelay()`: an increase pushes it out, a decrease cannot pull it in. Since `checkUpgradeDelayElapsed` tests the recomputed cycle _plus_ `COUNCIL_EXTRA_DELAY`, and a cancellation takes the recomputed cycle, the voter body keeps its full margin whatever the settings do — no bound on how far they may move is required.
 
 ## 5. Upgrade paths
 
@@ -166,6 +166,26 @@ gantt
 
 _Both paths over the same 42 days, aligned so the two `Execution` markers coincide. Top: a voter-body upgrade — voting delay, voting period, timelock delay — executable after 35 days. Bottom: a council upgrade, executable after a single 42-day delay. Both timelines are minimums: `queue` and `execute` are permissionless calls with no deadline, so every step can land later than drawn. The 7-day lead-in on the top chart is the voter body's margin to notice a scheduled council upgrade and to absorb that slack; a cancel cycle begun after it still lands at the council upgrade's execution._
 
+### Settings changes while an upgrade is pending
+
+A pending council upgrade carries two independent deadlines and executes only once both have passed:
+
+- **Frozen** — `TimelockController` stores `scheduledAt + upgradeDelay()` at scheduling and never revisits it.
+- **Recomputed** — `checkUpgradeDelayElapsed`, the batch's first call, recomputes `scheduledAt + upgradeDelay()` on every execution attempt.
+
+The effective deadline is the later of the two. A delay increase after scheduling pushes the recomputed deadline past the frozen one and delays the upgrade; a decrease leaves the frozen one binding and cannot pull the deadline in.
+
+The recomputed deadline is not monotonic, and that is the residual risk. An increase executing after scheduling moves the deadline out; a later decrease moves it back to the frozen one. A cancel proposal filed in between keeps the increased voting period, which `XanGovernor` snapshots at proposal creation — so the council's requirement shrinks instantly while the voter body's cancel cycle does not. Once the increase exceeds `COUNCIL_EXTRA_DELAY`, every cancel filed after it misses the restored deadline.
+
+Anyone can execute a queued timelock operation, so the voter body cannot choose when a settings change lands — only whether it is queued at all. It must therefore:
+
+1. Execute settings changes one at a time, never leaving contrary ones queued together.
+2. Check `getLastScheduledUpgradeOperationId` and `isOperationPending` before proposing a delay decrease, and hold it back while a council upgrade is pending.
+3. Size every cancel against `earliestExecutableAt` from `UpgradeScheduled` — the frozen deadline, the only one that cannot be revoked.
+4. File the cancel within `COUNCIL_EXTRA_DELAY` of scheduling and before any delay increase executes, so its cycle is snapshotted at the settings the frozen deadline was computed from.
+
+Rules 1 and 2 prevent the loss and are jointly sufficient; 3 and 4 are the margin if prevention fails. Rule 4 is unavailable when the increase executes in the same transaction as the scheduling, leaving 1 and 2 as the only defence. Once a decrease is queued there is no on-chain recourse, since cancelling it needs a voter-body proposal, which takes a full cycle itself.
+
 ## 6. Cancellation
 
 Cancellation is **one-way**: the voter body can cancel the council's pending upgrade, while the council can withdraw only its own.
@@ -197,6 +217,7 @@ The irreducible exception is an **inactive voter body**: when the electorate gen
 
 - **Inactive-voter honeypot (irreducible).** See section [Voter supremacy](#7-voter-supremacy). Bounded by the delay and by voters later replacing the council.
 - **A passed voter-body proposal is on-chain-unstoppable.** No actor holds a cancel over queued voter-body operations; the residual defense against a captured voter body is off-chain, within the timelock delay.
+- **Contrary settings proposals left queued.** An increase and a decrease of the timing settings, both queued and ready, let a pending council upgrade's deadline be pushed out and then pulled back, stranding a cancel filed in between. Execution is permissionless, so this is constrained by what the voter body queues; see section [Settings changes while an upgrade is pending](#settings-changes-while-an-upgrade-is-pending).
 - **A captured council is nearly powerless.** It can only schedule token upgrades — slower than a voter cycle and cancellable by the voter body — and withdraw its own pending one; it cannot cancel, stall, or veto voter-body operations. The backstop is council replacement / module revocation.
 - **One council upgrade in flight.** The module refuses a new council upgrade while one is pending; competing voter-body upgrades are unaffected, and the token's `reinitializer` version guard prevents a stale op from re-running.
 - **The council delay exceeds a full voter cancel cycle** (plus the extra delay) and is computed live, so it tracks changes to the governor settings and the timelock minimum — including changes that land _after_ the upgrade was scheduled, which the batch's leading `checkUpgradeDelayElapsed` call recomputes against (see [XanUpgradeCouncilModule](#4-xanupgradecouncilmodule)).

--- a/src/XanUpgradeCouncilModule.sol
+++ b/src/XanUpgradeCouncilModule.sol
@@ -149,7 +149,7 @@ contract XanUpgradeCouncilModule is IXanUpgradeCouncilModule {
     /// @inheritdoc IXanUpgradeCouncilModule
     /// @dev Runs as the first call of every council upgrade batch, so the timelock re-checks it on each execution
     /// attempt. The timelock freezes its deadline at scheduling while a cancel cycle is computed live, so a later
-    /// settings raise would otherwise let the upgrade outrun any cancellation.
+    /// delay increase would otherwise let the upgrade outrun any cancellation.
     function checkUpgradeDelayElapsed(uint48 scheduledAt) external view override {
         uint256 executableAt = scheduledAt + upgradeDelay();
         require(

--- a/src/interfaces/IXanUpgradeCouncilModule.sol
+++ b/src/interfaces/IXanUpgradeCouncilModule.sol
@@ -12,7 +12,7 @@ interface IXanUpgradeCouncilModule {
     /// @param data The reinitialization calldata forwarded to `upgradeToAndCall`.
     /// @param scheduledAt The timestamp the upgrade was scheduled at, which `checkUpgradeDelayElapsed` measures its
     /// delay from.
-    /// @param earliestExecutableAt The earliest timestamp the upgrade can execute; a later settings raise pushes the
+    /// @param earliestExecutableAt The earliest timestamp the upgrade can execute; a later delay increase pushes the
     /// actual moment out, nothing moves it in.
     event UpgradeScheduled(
         address indexed newImplementation,

--- a/test/XanUpgradeCouncilModule.timing.t.sol
+++ b/test/XanUpgradeCouncilModule.timing.t.sol
@@ -9,9 +9,9 @@ import {Parameters} from "../src/libs/Parameters.sol";
 import {XanUpgradeCouncilModule} from "../src/XanUpgradeCouncilModule.sol";
 import {XanUpgradeCouncilModuleFixture} from "./fixtures/XanUpgradeCouncilModuleFixture.sol";
 
-/// @notice Regression tests for the schedule-then-raise attack: the council schedules an upgrade and, in the same
-/// transaction, executes an already-passed voter-body proposal raising the timing settings, so every later cancel
-/// cycle would outrun a deadline frozen at scheduling.
+/// @notice Tests for timing settings that change while a council upgrade is pending: an increase after scheduling
+/// pushes the deadline out, a decrease cannot pull it in, and an increase undone by a later decrease lets the upgrade
+/// outrun a cancel already in flight.
 /// @dev Runs at the production governor settings. The base fixture's compressed ones hide the race, moving the cancel
 /// cycle by seconds against a days-scale margin.
 contract XanUpgradeCouncilModuleTimingTest is XanUpgradeCouncilModuleFixture {
@@ -30,7 +30,10 @@ contract XanUpgradeCouncilModuleTimingTest is XanUpgradeCouncilModuleFixture {
     /// start the margin is meant to cover.
     uint256 private constant _MARGIN_LEFT_AT_CANCEL = 1 hours;
 
-    /// @notice A raise whose voting period alone outlasts the whole delay the upgrade was scheduled with, so no
+    /// @notice Shared by every voting-period proposal below, so queueing and executing one derive the same salt.
+    string private constant _VOTING_PERIOD_CHANGE_DESCRIPTION = "change the voting period";
+
+    /// @notice An increase whose voting period alone outlasts the whole delay the upgrade was scheduled with, so no
     /// bound sized against that delay could have covered it.
     /// @dev `immutable`, not `constant`, so the narrowing to the `uint32` a voting period is stays checked — a
     /// `constant` initializer cannot call `SafeCast`.
@@ -39,10 +42,10 @@ contract XanUpgradeCouncilModuleTimingTest is XanUpgradeCouncilModuleFixture {
     uint256 private immutable _UPGRADE_DELAY_AT_EXCEEDING_PERIOD =
         _UPGRADE_DELAY - Parameters.GOVERNOR_VOTING_PERIOD + _VOTING_PERIOD_EXCEEDING_UPGRADE_DELAY;
 
-    /// @notice A passed voting-period raise waits in the timelock; the council schedules an upgrade and executes the
-    /// raise in one batch, so the timelock's frozen deadline is computed from the old settings while every
+    /// @notice A passed voting-period increase waits in the timelock; the council schedules an upgrade and executes
+    /// the increase in one batch, so the timelock's frozen deadline is computed from the old settings while every
     /// cancellation runs at the new ones.
-    function test_voter_body_can_cancel_after_a_queued_settings_raise_executes_post_scheduling() public {
+    function test_voter_body_can_cancel_after_a_queued_delay_increase_executes_post_scheduling() public {
         assertGt(
             _VOTING_PERIOD_EXCEEDING_UPGRADE_DELAY,
             _UPGRADE_DELAY,
@@ -51,21 +54,20 @@ contract XanUpgradeCouncilModuleTimingTest is XanUpgradeCouncilModuleFixture {
         assertGt(
             _UPGRADE_DELAY_AT_EXCEEDING_PERIOD - Parameters.COUNCIL_EXTRA_DELAY,
             _UPGRADE_DELAY,
-            "the raised cancel cycle must outrun the frozen deadline, or there is no race to close"
+            "the increased cancel cycle must outrun the frozen deadline, or there is no race to close"
         );
 
-        // A passed proposal raising the voting period, queued and past its timelock delay but not executed — an
+        // A passed proposal increasing the voting period, queued and past its timelock delay but not executed — an
         // ordinary state, since nobody is obliged to execute promptly.
-        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas, bytes32 descriptionHash) =
-            _queueVotingPeriodChange(_VOTING_PERIOD_EXCEEDING_UPGRADE_DELAY);
+        _queueVotingPeriodChange(_VOTING_PERIOD_EXCEEDING_UPGRADE_DELAY);
         skip(_timelock.getMinDelay() + 1 seconds);
 
-        // The council's move: schedule the upgrade, then execute the raise, leaving no block in between for a
+        // The council's move: schedule the upgrade, then execute the increase, leaving no block in between for a
         // cancellation to be filed under the old settings.
         address newImpl = _newImplementation();
         (bytes32 operationId, uint48 scheduledAt) = _scheduleCouncilUpgrade(newImpl, "");
         uint256 frozenExecutableAt = scheduledAt + _module.upgradeDelay();
-        _governor.execute(targets, values, calldatas, descriptionHash);
+        _executeVotingPeriodChange(_VOTING_PERIOD_EXCEEDING_UPGRADE_DELAY);
         assertEq(_governor.votingPeriod(), _VOTING_PERIOD_EXCEEDING_UPGRADE_DELAY);
         assertEq(_module.upgradeDelay(), _UPGRADE_DELAY_AT_EXCEEDING_PERIOD);
 
@@ -73,7 +75,7 @@ contract XanUpgradeCouncilModuleTimingTest is XanUpgradeCouncilModuleFixture {
         assertGt(
             recomputedExecutableAt,
             frozenExecutableAt,
-            "the raise must push the recomputed deadline past the one the timelock froze"
+            "the increase must push the recomputed deadline past the one the timelock froze"
         );
 
         // At the now-stale frozen deadline `checkUpgradeDelayElapsed` reverts, and the timelock keeps the operation
@@ -104,9 +106,9 @@ contract XanUpgradeCouncilModuleTimingTest is XanUpgradeCouncilModuleFixture {
         _executeCouncilUpgrade(newImpl, "", scheduledAt);
     }
 
-    /// @notice Settings lowered after scheduling cannot pull the deadline in, because the timelock's frozen
+    /// @notice A delay decrease after scheduling cannot pull the deadline in, because the timelock's frozen
     /// timestamp still applies. The effective deadline is the later of the two.
-    function test_a_settings_cut_after_scheduling_does_not_shorten_the_upgrade_delay() public {
+    function test_a_delay_decrease_after_scheduling_does_not_shorten_the_upgrade_delay() public {
         address newImpl = _newImplementation();
         (bytes32 operationId, uint48 scheduledAt) = _scheduleCouncilUpgrade(newImpl, "");
         uint256 frozenExecutableAt = scheduledAt + _module.upgradeDelay();
@@ -116,7 +118,7 @@ contract XanUpgradeCouncilModuleTimingTest is XanUpgradeCouncilModuleFixture {
         assertLt(
             scheduledAt + _module.upgradeDelay(),
             frozenExecutableAt,
-            "the cut must pull the recomputed deadline in, leaving only the frozen one binding"
+            "the decrease must pull the recomputed deadline in, leaving only the frozen one binding"
         );
 
         // The timelock still holds the operation until its own frozen deadline.
@@ -127,6 +129,42 @@ contract XanUpgradeCouncilModuleTimingTest is XanUpgradeCouncilModuleFixture {
         vm.warp(frozenExecutableAt);
         _executeCouncilUpgrade(newImpl, "", scheduledAt);
         assertEq(_xanToken.implementation(), newImpl);
+    }
+
+    /// @notice An increase executing after scheduling pushes the deadline out, and a later decrease restores the
+    /// frozen one. A cancel cycle started in between keeps the increased voting period — `XanGovernor` snapshots it at
+    /// proposal creation — so it no longer finishes in time. The voter body prevents this by never leaving contrary
+    /// settings proposals queued at once, there being no on-chain recourse once the decrease is queued.
+    function test_a_delay_decrease_undoing_an_increase_lets_the_upgrade_outrun_an_in_flight_cancel() public {
+        // Contrary settings proposals, both passed and queued past their timelock delay, neither executed.
+        _queueVotingPeriodChange(_VOTING_PERIOD_EXCEEDING_UPGRADE_DELAY);
+        _queueVotingPeriodChange(Parameters.GOVERNOR_VOTING_PERIOD);
+        skip(_timelock.getMinDelay() + 1 seconds);
+
+        address newImpl = _newImplementation();
+        (bytes32 operationId, uint48 scheduledAt) = _scheduleCouncilUpgrade(newImpl, "");
+        uint256 frozenExecutableAt = scheduledAt + _module.upgradeDelay();
+
+        _executeVotingPeriodChange(_VOTING_PERIOD_EXCEEDING_UPGRADE_DELAY);
+        assertEq(_module.upgradeDelay(), _UPGRADE_DELAY_AT_EXCEEDING_PERIOD);
+        uint256 increasedExecutableAt = scheduledAt + _module.upgradeDelay();
+        assertGt(increasedExecutableAt, frozenExecutableAt, "the increase must push the deadline past the frozen one");
+
+        // The voter body starts its cancel cycle at the edge of its margin, sized against the increased deadline.
+        vm.warp(scheduledAt + Parameters.COUNCIL_EXTRA_DELAY - _MARGIN_LEFT_AT_CANCEL);
+        uint256 cancelCompletesAt = _proposeCancelCouncilUpgrade(operationId) + _timelock.getMinDelay();
+        assertLt(cancelCompletesAt, increasedExecutableAt, "the cancel must fit inside the increased deadline");
+
+        // Undoing the increase restores the frozen deadline, which the cycle already under way cannot meet.
+        _executeVotingPeriodChange(Parameters.GOVERNOR_VOTING_PERIOD);
+        assertEq(
+            scheduledAt + _module.upgradeDelay(), frozenExecutableAt, "the decrease must restore the frozen deadline"
+        );
+        assertGt(cancelCompletesAt, frozenExecutableAt, "the cancel under way must now miss the deadline");
+
+        vm.warp(frozenExecutableAt);
+        _executeCouncilUpgrade(newImpl, "", scheduledAt);
+        assertEq(_xanToken.implementation(), newImpl, "the upgrade lands before the cancel can complete");
     }
 
     /// @notice `checkUpgradeDelayElapsed` is callable by anyone, for off-chain monitoring, and passes exactly at
@@ -160,18 +198,36 @@ contract XanUpgradeCouncilModuleTimingTest is XanUpgradeCouncilModuleFixture {
     function _passVotingPeriodChange(uint32 newVotingPeriod) private {
         (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) =
             _setVotingPeriodCall(newVotingPeriod);
-        _passProposal({targets: targets, values: values, calldatas: calldatas, description: "change the voting period"});
+        _passProposal({
+            targets: targets, values: values, calldatas: calldatas, description: _VOTING_PERIOD_CHANGE_DESCRIPTION
+        });
     }
 
     /// @notice Queues (but does not execute) a proposal setting the governor's voting period.
-    function _queueVotingPeriodChange(uint32 newVotingPeriod)
-        private
-        returns (address[] memory targets, uint256[] memory values, bytes[] memory calldatas, bytes32 descriptionHash)
-    {
-        (targets, values, calldatas) = _setVotingPeriodCall(newVotingPeriod);
-        descriptionHash = _queueVoterBodyProposal({
-            targets: targets, values: values, calldatas: calldatas, description: "change the voting period"
+    function _queueVotingPeriodChange(uint32 newVotingPeriod) private {
+        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) =
+            _setVotingPeriodCall(newVotingPeriod);
+        _queueVoterBodyProposal({
+            targets: targets, values: values, calldatas: calldatas, description: _VOTING_PERIOD_CHANGE_DESCRIPTION
         });
+    }
+
+    /// @notice Executes a voting-period change already queued by `_queueVotingPeriodChange`.
+    function _executeVotingPeriodChange(uint32 newVotingPeriod) private {
+        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) =
+            _setVotingPeriodCall(newVotingPeriod);
+        _governor.execute(targets, values, calldatas, keccak256(bytes(_VOTING_PERIOD_CHANGE_DESCRIPTION)));
+    }
+
+    /// @notice Files the voter body's cancel proposal without running it to completion.
+    /// @return voteEnd The timestamp the cancel proposal's voting closes at, fixed by the settings in force now.
+    function _proposeCancelCouncilUpgrade(bytes32 operationId) private returns (uint256 voteEnd) {
+        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) =
+            _cancelCouncilUpgradeCall(operationId);
+
+        vm.prank(_voterA);
+        uint256 proposalId = _governor.propose(targets, values, calldatas, "cancel the council upgrade");
+        voteEnd = _governor.proposalDeadline(proposalId);
     }
 
     function _setVotingPeriodCall(uint32 newVotingPeriod)


### PR DESCRIPTION
An increase after scheduling pushes the recomputed deadline out; a later decrease restores the frozen one, which a cancel filed in between can no longer meet. Pinned by a test.